### PR TITLE
Merge cloudWatchExecutor into DataSource

### DIFF
--- a/pkg/cloudwatch/annotation_query.go
+++ b/pkg/cloudwatch/annotation_query.go
@@ -23,7 +23,7 @@ type annotationEvent struct {
 	Text  string
 }
 
-func (e *cloudWatchExecutor) executeAnnotationQuery(ctx context.Context, pluginCtx backend.PluginContext, model DataQueryJson, query backend.DataQuery) (*backend.QueryDataResponse, error) {
+func (ds *DataSource) executeAnnotationQuery(ctx context.Context, pluginCtx backend.PluginContext, model DataQueryJson, query backend.DataQuery) (*backend.QueryDataResponse, error) {
 	result := backend.NewQueryDataResponse()
 	statistic := ""
 
@@ -52,7 +52,7 @@ func (e *cloudWatchExecutor) executeAnnotationQuery(ctx context.Context, pluginC
 	actionPrefix := model.ActionPrefix
 	alarmNamePrefix := model.AlarmNamePrefix
 
-	cli, err := e.getCWClient(ctx, pluginCtx, model.Region)
+	cli, err := ds.getCWClient(ctx, pluginCtx, model.Region)
 	if err != nil {
 		result.Responses[query.RefID] = backend.ErrorResponseWithErrorSource(fmt.Errorf("%v: %w", "failed to get client", err))
 		return result, nil

--- a/pkg/cloudwatch/get_dimension_values_for_wildcards.go
+++ b/pkg/cloudwatch/get_dimension_values_for_wildcards.go
@@ -27,7 +27,7 @@ func shouldSkipFetchingWildcards(ctx context.Context, q *models.CloudWatchQuery)
 }
 
 // getDimensionValues gets the actual dimension values for dimensions with a wildcard
-func (e *cloudWatchExecutor) getDimensionValuesForWildcards(
+func (ds *DataSource) getDimensionValuesForWildcards(
 	ctx context.Context,
 	region string,
 	client models.CWClient,
@@ -58,12 +58,12 @@ func (e *cloudWatchExecutor) getDimensionValuesForWildcards(
 			cacheKey := fmt.Sprintf("%s-%s-%s-%s-%s", region, accountID, query.Namespace, query.MetricName, dimensionKey)
 			cachedDimensions, found := tagValueCache.Get(cacheKey)
 			if found {
-				e.logger.FromContext(ctx).Debug("Fetching dimension values from cache")
+				ds.logger.FromContext(ctx).Debug("Fetching dimension values from cache")
 				query.Dimensions[dimensionKey] = cachedDimensions.([]string)
 				continue
 			}
 
-			e.logger.FromContext(ctx).Debug("Cache miss, fetching dimension values from AWS")
+			ds.logger.FromContext(ctx).Debug("Cache miss, fetching dimension values from AWS")
 			request := resources.DimensionValuesRequest{
 				ResourceRequest: &resources.ResourceRequest{
 					Region:    region,

--- a/pkg/cloudwatch/get_dimension_values_for_wildcards_test.go
+++ b/pkg/cloudwatch/get_dimension_values_for_wildcards_test.go
@@ -18,7 +18,7 @@ import (
 func noSkip(ctx context.Context, q *models.CloudWatchQuery) bool { return false }
 
 func TestGetDimensionValuesForWildcards(t *testing.T) {
-	executor := &cloudWatchExecutor{im: defaultTestInstanceManager(), logger: log.NewNullLogger()}
+	executor := &DataSource{im: defaultTestInstanceManager(), logger: log.NewNullLogger()}
 	ctx := context.Background()
 
 	t.Run("Tag value cache", func(t *testing.T) {

--- a/pkg/cloudwatch/get_metric_data_executor.go
+++ b/pkg/cloudwatch/get_metric_data_executor.go
@@ -13,7 +13,7 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 )
 
-func (e *cloudWatchExecutor) executeRequest(ctx context.Context, client models.CWClient,
+func (ds *DataSource) executeRequest(ctx context.Context, client models.CWClient,
 	metricDataInput *cloudwatch.GetMetricDataInput) ([]*cloudwatch.GetMetricDataOutput, error) {
 	mdo := make([]*cloudwatch.GetMetricDataOutput, 0)
 

--- a/pkg/cloudwatch/get_metric_data_executor_test.go
+++ b/pkg/cloudwatch/get_metric_data_executor_test.go
@@ -18,7 +18,7 @@ import (
 
 func TestGetMetricDataExecutorTestRequest(t *testing.T) {
 	t.Run("Should round up end time if cloudWatchRoundUpEndTime is enabled", func(t *testing.T) {
-		executor := &cloudWatchExecutor{}
+		executor := &DataSource{}
 		queryEndTime, _ := time.Parse("2006-01-02T15:04:05Z07:00", "2024-05-01T01:45:04Z")
 		inputs := &cloudwatch.GetMetricDataInput{EndTime: &queryEndTime, MetricDataQueries: []cloudwatchtypes.MetricDataQuery{}}
 		mockMetricClient := &mocks.MetricsAPI{}
@@ -35,7 +35,7 @@ func TestGetMetricDataExecutorTestRequest(t *testing.T) {
 }
 
 func TestGetMetricDataExecutorTestResponse(t *testing.T) {
-	executor := &cloudWatchExecutor{}
+	executor := &DataSource{}
 	inputs := &cloudwatch.GetMetricDataInput{EndTime: aws.Time(time.Now()), MetricDataQueries: []cloudwatchtypes.MetricDataQuery{}}
 	mockMetricClient := &mocks.MetricsAPI{}
 	mockMetricClient.On("GetMetricData", mock.Anything, mock.Anything, mock.Anything).Return(

--- a/pkg/cloudwatch/log_actions.go
+++ b/pkg/cloudwatch/log_actions.go
@@ -42,7 +42,7 @@ func (e *AWSError) Error() string {
 	return fmt.Sprintf("CloudWatch error: %s: %s", e.Code, e.Message)
 }
 
-func (e *cloudWatchExecutor) executeLogActions(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+func (ds *DataSource) executeLogActions(ctx context.Context, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
 	resp := backend.NewQueryDataResponse()
 
 	resultChan := make(chan backend.Responses, len(req.Queries))
@@ -57,7 +57,7 @@ func (e *cloudWatchExecutor) executeLogActions(ctx context.Context, req *backend
 
 		query := query
 		eg.Go(func() error {
-			dataframe, err := e.executeLogAction(ectx, logsQuery, query, req.PluginContext)
+			dataframe, err := ds.executeLogAction(ectx, logsQuery, query, req.PluginContext)
 			if err != nil {
 				resultChan <- backend.Responses{
 					query.RefID: backend.ErrorResponseWithErrorSource(err),
@@ -94,8 +94,8 @@ func (e *cloudWatchExecutor) executeLogActions(ctx context.Context, req *backend
 	return resp, nil
 }
 
-func (e *cloudWatchExecutor) executeLogAction(ctx context.Context, logsQuery models.LogsQuery, query backend.DataQuery, pluginCtx backend.PluginContext) (*data.Frame, error) {
-	instance, err := e.getInstance(ctx, pluginCtx)
+func (ds *DataSource) executeLogAction(ctx context.Context, logsQuery models.LogsQuery, query backend.DataQuery, pluginCtx backend.PluginContext) (*data.Frame, error) {
+	instance, err := ds.getInstance(ctx, pluginCtx)
 	if err != nil {
 		return nil, err
 	}
@@ -105,7 +105,7 @@ func (e *cloudWatchExecutor) executeLogAction(ctx context.Context, logsQuery mod
 		region = logsQuery.Region
 	}
 
-	logsClient, err := e.getCWLogsClient(ctx, pluginCtx, region)
+	logsClient, err := ds.getCWLogsClient(ctx, pluginCtx, region)
 	if err != nil {
 		return nil, err
 	}
@@ -113,13 +113,13 @@ func (e *cloudWatchExecutor) executeLogAction(ctx context.Context, logsQuery mod
 	var data *data.Frame = nil
 	switch logsQuery.Subtype {
 	case "StartQuery":
-		data, err = e.handleStartQuery(ctx, logsClient, logsQuery, query.TimeRange, query.RefID)
+		data, err = ds.handleStartQuery(ctx, logsClient, logsQuery, query.TimeRange, query.RefID)
 	case "StopQuery":
-		data, err = e.handleStopQuery(ctx, logsClient, logsQuery)
+		data, err = ds.handleStopQuery(ctx, logsClient, logsQuery)
 	case "GetQueryResults":
-		data, err = e.handleGetQueryResults(ctx, logsClient, logsQuery, query.RefID)
+		data, err = ds.handleGetQueryResults(ctx, logsClient, logsQuery, query.RefID)
 	case "GetLogEvents":
-		data, err = e.handleGetLogEvents(ctx, logsClient, logsQuery)
+		data, err = ds.handleGetLogEvents(ctx, logsClient, logsQuery)
 	}
 	if err != nil {
 		return nil, fmt.Errorf("failed to execute log action with subtype: %s: %w", logsQuery.Subtype, err)
@@ -128,7 +128,7 @@ func (e *cloudWatchExecutor) executeLogAction(ctx context.Context, logsQuery mod
 	return data, nil
 }
 
-func (e *cloudWatchExecutor) handleGetLogEvents(ctx context.Context, logsClient models.CWLogsClient,
+func (ds *DataSource) handleGetLogEvents(ctx context.Context, logsClient models.CWLogsClient,
 	logsQuery models.LogsQuery) (*data.Frame, error) {
 	limit := defaultEventLimit
 	if logsQuery.Limit != nil && *logsQuery.Limit > 0 {
@@ -181,7 +181,7 @@ func (e *cloudWatchExecutor) handleGetLogEvents(ctx context.Context, logsClient 
 	return data.NewFrame("logEvents", timestampField, messageField), nil
 }
 
-func (e *cloudWatchExecutor) executeStartQuery(ctx context.Context, logsClient models.CWLogsClient,
+func (ds *DataSource) executeStartQuery(ctx context.Context, logsClient models.CWLogsClient,
 	logsQuery models.LogsQuery, timeRange backend.TimeRange) (*cloudwatchlogs.StartQueryOutput, error) {
 	startTime := timeRange.From
 	endTime := timeRange.To
@@ -239,22 +239,22 @@ func (e *cloudWatchExecutor) executeStartQuery(ctx context.Context, logsClient m
 		startQueryInput.QueryLanguage = cloudwatchlogstypes.QueryLanguage(*logsQuery.QueryLanguage)
 	}
 
-	e.logger.FromContext(ctx).Debug("Calling startquery with context with input", "input", startQueryInput)
+	ds.logger.FromContext(ctx).Debug("Calling startquery with context with input", "input", startQueryInput)
 	resp, err := logsClient.StartQuery(ctx, startQueryInput)
 	if err != nil {
 		if errors.Is(err, &cloudwatchlogstypes.LimitExceededException{}) {
-			e.logger.FromContext(ctx).Debug("ExecuteStartQuery limit exceeded", "err", err)
+			ds.logger.FromContext(ctx).Debug("ExecuteStartQuery limit exceeded", "err", err)
 		} else if errors.Is(err, &cloudwatchlogstypes.ThrottlingException{}) {
-			e.logger.FromContext(ctx).Debug("ExecuteStartQuery rate exceeded", "err", err)
+			ds.logger.FromContext(ctx).Debug("ExecuteStartQuery rate exceeded", "err", err)
 		}
 		err = backend.DownstreamError(err)
 	}
 	return resp, err
 }
 
-func (e *cloudWatchExecutor) handleStartQuery(ctx context.Context, logsClient models.CWLogsClient,
+func (ds *DataSource) handleStartQuery(ctx context.Context, logsClient models.CWLogsClient,
 	logsQuery models.LogsQuery, timeRange backend.TimeRange, refID string) (*data.Frame, error) {
-	startQueryResponse, err := e.executeStartQuery(ctx, logsClient, logsQuery, timeRange)
+	startQueryResponse, err := ds.executeStartQuery(ctx, logsClient, logsQuery, timeRange)
 	if err != nil {
 		return nil, err
 	}
@@ -276,7 +276,7 @@ func (e *cloudWatchExecutor) handleStartQuery(ctx context.Context, logsClient mo
 	return dataFrame, nil
 }
 
-func (e *cloudWatchExecutor) executeStopQuery(ctx context.Context, logsClient models.CWLogsClient,
+func (ds *DataSource) executeStopQuery(ctx context.Context, logsClient models.CWLogsClient,
 	logsQuery models.LogsQuery) (*cloudwatchlogs.StopQueryOutput, error) {
 	queryInput := &cloudwatchlogs.StopQueryInput{
 		QueryId: aws.String(logsQuery.QueryId),
@@ -298,9 +298,9 @@ func (e *cloudWatchExecutor) executeStopQuery(ctx context.Context, logsClient mo
 	return response, err
 }
 
-func (e *cloudWatchExecutor) handleStopQuery(ctx context.Context, logsClient models.CWLogsClient,
+func (ds *DataSource) handleStopQuery(ctx context.Context, logsClient models.CWLogsClient,
 	logsQuery models.LogsQuery) (*data.Frame, error) {
-	response, err := e.executeStopQuery(ctx, logsClient, logsQuery)
+	response, err := ds.executeStopQuery(ctx, logsClient, logsQuery)
 	if err != nil {
 		return nil, err
 	}
@@ -309,7 +309,7 @@ func (e *cloudWatchExecutor) handleStopQuery(ctx context.Context, logsClient mod
 	return dataFrame, nil
 }
 
-func (e *cloudWatchExecutor) executeGetQueryResults(ctx context.Context, logsClient models.CWLogsClient,
+func (ds *DataSource) executeGetQueryResults(ctx context.Context, logsClient models.CWLogsClient,
 	logsQuery models.LogsQuery) (*cloudwatchlogs.GetQueryResultsOutput, error) {
 	queryInput := &cloudwatchlogs.GetQueryResultsInput{
 		QueryId: aws.String(logsQuery.QueryId),
@@ -326,9 +326,9 @@ func (e *cloudWatchExecutor) executeGetQueryResults(ctx context.Context, logsCli
 	return getQueryResultsResponse, err
 }
 
-func (e *cloudWatchExecutor) handleGetQueryResults(ctx context.Context, logsClient models.CWLogsClient,
+func (ds *DataSource) handleGetQueryResults(ctx context.Context, logsClient models.CWLogsClient,
 	logsQuery models.LogsQuery, refID string) (*data.Frame, error) {
-	getQueryResultsOutput, err := e.executeGetQueryResults(ctx, logsClient, logsQuery)
+	getQueryResultsOutput, err := ds.executeGetQueryResults(ctx, logsClient, logsQuery)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cloudwatch/log_sync_query.go
+++ b/pkg/cloudwatch/log_sync_query.go
@@ -17,7 +17,7 @@ import (
 
 const initialAlertPollPeriod = time.Second
 
-var executeSyncLogQuery = func(ctx context.Context, e *cloudWatchExecutor, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+var executeSyncLogQuery = func(ctx context.Context, e *DataSource, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
 	resp := backend.NewQueryDataResponse()
 
 	instance, err := e.getInstance(ctx, req.PluginContext)
@@ -86,9 +86,9 @@ var executeSyncLogQuery = func(ctx context.Context, e *cloudWatchExecutor, req *
 	return resp, nil
 }
 
-func (e *cloudWatchExecutor) syncQuery(ctx context.Context, logsClient models.CWLogsClient,
+func (ds *DataSource) syncQuery(ctx context.Context, logsClient models.CWLogsClient,
 	queryContext backend.DataQuery, logsQuery models.LogsQuery, logsTimeout time.Duration) (*cloudwatchlogs.GetQueryResultsOutput, error) {
-	startQueryOutput, err := e.executeStartQuery(ctx, logsClient, logsQuery, queryContext.TimeRange)
+	startQueryOutput, err := ds.executeStartQuery(ctx, logsClient, logsQuery, queryContext.TimeRange)
 	if err != nil {
 		return nil, err
 	}
@@ -113,7 +113,7 @@ func (e *cloudWatchExecutor) syncQuery(ctx context.Context, logsClient models.CW
 
 	attemptCount := 1
 	for range ticker.C {
-		res, err := e.executeGetQueryResults(ctx, logsClient, requestParams)
+		res, err := ds.executeGetQueryResults(ctx, logsClient, requestParams)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/cloudwatch/log_sync_query_test.go
+++ b/pkg/cloudwatch/log_sync_query_test.go
@@ -103,7 +103,7 @@ func Test_executeSyncLogQuery(t *testing.T) {
 		}
 		origExecuteSyncLogQuery := executeSyncLogQuery
 		var syncCalled bool
-		executeSyncLogQuery = func(ctx context.Context, e *cloudWatchExecutor, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+		executeSyncLogQuery = func(ctx context.Context, e *DataSource, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
 			syncCalled = true
 			return nil, nil
 		}
@@ -143,7 +143,7 @@ func Test_executeSyncLogQuery(t *testing.T) {
 	t.Run("when query mode is 'Logs' and does not include type or subtype", func(t *testing.T) {
 		origExecuteSyncLogQuery := executeSyncLogQuery
 		syncCalled := false
-		executeSyncLogQuery = func(ctx context.Context, e *cloudWatchExecutor, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
+		executeSyncLogQuery = func(ctx context.Context, e *DataSource, req *backend.QueryDataRequest) (*backend.QueryDataResponse, error) {
 			syncCalled = true
 			return nil, nil
 		}

--- a/pkg/cloudwatch/metric_data_input_builder.go
+++ b/pkg/cloudwatch/metric_data_input_builder.go
@@ -11,7 +11,7 @@ import (
 	"github.com/grafana/grafana-cloudwatch-datasource/pkg/cloudwatch/models"
 )
 
-func (e *cloudWatchExecutor) buildMetricDataInput(ctx context.Context, startTime time.Time, endTime time.Time,
+func (ds *DataSource) buildMetricDataInput(ctx context.Context, startTime time.Time, endTime time.Time,
 	queries []*models.CloudWatchQuery) (*cloudwatch.GetMetricDataInput, error) {
 	metricDataInput := &cloudwatch.GetMetricDataInput{
 		StartTime: aws.Time(startTime),
@@ -28,7 +28,7 @@ func (e *cloudWatchExecutor) buildMetricDataInput(ctx context.Context, startTime
 	}
 
 	for _, query := range queries {
-		metricDataQuery, err := e.buildMetricDataQuery(ctx, query)
+		metricDataQuery, err := ds.buildMetricDataQuery(ctx, query)
 		if err != nil {
 			return nil, &models.QueryError{Err: err, RefID: query.RefId}
 		}

--- a/pkg/cloudwatch/metric_data_query_builder.go
+++ b/pkg/cloudwatch/metric_data_query_builder.go
@@ -15,7 +15,7 @@ import (
 
 const keySeparator = "|&|"
 
-func (e *cloudWatchExecutor) buildMetricDataQuery(ctx context.Context, query *models.CloudWatchQuery) (cloudwatchtypes.MetricDataQuery, error) {
+func (ds *DataSource) buildMetricDataQuery(ctx context.Context, query *models.CloudWatchQuery) (cloudwatchtypes.MetricDataQuery, error) {
 	mdq := cloudwatchtypes.MetricDataQuery{
 		Id:         aws.String(query.Id),
 		ReturnData: aws.Bool(query.ReturnData),

--- a/pkg/cloudwatch/metric_find_query.go
+++ b/pkg/cloudwatch/metric_find_query.go
@@ -43,12 +43,12 @@ func parseMultiSelectValue(input string) []string {
 	return []string{trimmedInput}
 }
 
-func (e *cloudWatchExecutor) handleGetEbsVolumeIds(ctx context.Context, pluginCtx backend.PluginContext, parameters url.Values) ([]suggestData, error) {
+func (ds *DataSource) handleGetEbsVolumeIds(ctx context.Context, pluginCtx backend.PluginContext, parameters url.Values) ([]suggestData, error) {
 	region := parameters.Get("region")
 	instanceId := parameters.Get("instanceId")
 
 	instanceIds := parseMultiSelectValue(instanceId)
-	instances, err := e.ec2DescribeInstances(ctx, pluginCtx, region, nil, instanceIds)
+	instances, err := ds.ec2DescribeInstances(ctx, pluginCtx, region, nil, instanceIds)
 	if err != nil {
 		return nil, err
 	}
@@ -65,7 +65,7 @@ func (e *cloudWatchExecutor) handleGetEbsVolumeIds(ctx context.Context, pluginCt
 	return result, nil
 }
 
-func (e *cloudWatchExecutor) handleGetEc2InstanceAttribute(ctx context.Context, pluginCtx backend.PluginContext, parameters url.Values) ([]suggestData, error) {
+func (ds *DataSource) handleGetEc2InstanceAttribute(ctx context.Context, pluginCtx backend.PluginContext, parameters url.Values) ([]suggestData, error) {
 	region := parameters.Get("region")
 	attributeName := parameters.Get("attributeName")
 	filterJson := parameters.Get("filters")
@@ -92,7 +92,7 @@ func (e *cloudWatchExecutor) handleGetEc2InstanceAttribute(ctx context.Context, 
 		}
 	}
 
-	instances, err := e.ec2DescribeInstances(ctx, pluginCtx, region, filters, nil)
+	instances, err := ds.ec2DescribeInstances(ctx, pluginCtx, region, filters, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -177,7 +177,7 @@ func getInstanceAttributeValue(attributeName string, instance ec2types.Instance)
 	return data, true, nil
 }
 
-func (e *cloudWatchExecutor) handleGetResourceArns(ctx context.Context, pluginCtx backend.PluginContext, parameters url.Values) ([]suggestData, error) {
+func (ds *DataSource) handleGetResourceArns(ctx context.Context, pluginCtx backend.PluginContext, parameters url.Values) ([]suggestData, error) {
 	region := parameters.Get("region")
 	resourceType := parameters.Get("resourceType")
 	tagsJson := parameters.Get("tags")
@@ -206,7 +206,7 @@ func (e *cloudWatchExecutor) handleGetResourceArns(ctx context.Context, pluginCt
 
 	resourceTypes := []string{resourceType}
 
-	resources, err := e.resourceGroupsGetResources(ctx, pluginCtx, region, filters, resourceTypes)
+	resources, err := ds.resourceGroupsGetResources(ctx, pluginCtx, region, filters, resourceTypes)
 	if err != nil {
 		return nil, err
 	}
@@ -220,13 +220,13 @@ func (e *cloudWatchExecutor) handleGetResourceArns(ctx context.Context, pluginCt
 	return result, nil
 }
 
-func (e *cloudWatchExecutor) ec2DescribeInstances(ctx context.Context, pluginCtx backend.PluginContext, region string, filters []ec2types.Filter, instanceIds []string) (*ec2.DescribeInstancesOutput, error) {
+func (ds *DataSource) ec2DescribeInstances(ctx context.Context, pluginCtx backend.PluginContext, region string, filters []ec2types.Filter, instanceIds []string) (*ec2.DescribeInstancesOutput, error) {
 	params := &ec2.DescribeInstancesInput{
 		Filters:     filters,
 		InstanceIds: instanceIds,
 	}
 
-	client, err := e.getEC2Client(ctx, pluginCtx, region)
+	client, err := ds.getEC2Client(ctx, pluginCtx, region)
 	if err != nil {
 		return nil, err
 	}
@@ -243,14 +243,14 @@ func (e *cloudWatchExecutor) ec2DescribeInstances(ctx context.Context, pluginCtx
 	return resp, nil
 }
 
-func (e *cloudWatchExecutor) resourceGroupsGetResources(ctx context.Context, pluginCtx backend.PluginContext, region string, filters []resourcegroupstaggingapitypes.TagFilter,
+func (ds *DataSource) resourceGroupsGetResources(ctx context.Context, pluginCtx backend.PluginContext, region string, filters []resourcegroupstaggingapitypes.TagFilter,
 	resourceTypes []string) (*resourcegroupstaggingapi.GetResourcesOutput, error) {
 	params := &resourcegroupstaggingapi.GetResourcesInput{
 		ResourceTypeFilters: resourceTypes,
 		TagFilters:          filters,
 	}
 
-	client, err := e.getRGTAClient(ctx, pluginCtx, region)
+	client, err := ds.getRGTAClient(ctx, pluginCtx, region)
 	if err != nil {
 		return nil, err
 	}
@@ -269,12 +269,12 @@ func (e *cloudWatchExecutor) resourceGroupsGetResources(ctx context.Context, plu
 }
 
 // legacy route, will be removed once GovCloud supports Cross Account Observability
-func (e *cloudWatchExecutor) handleGetLogGroups(ctx context.Context, pluginCtx backend.PluginContext, parameters url.Values) ([]suggestData, error) {
+func (ds *DataSource) handleGetLogGroups(ctx context.Context, pluginCtx backend.PluginContext, parameters url.Values) ([]suggestData, error) {
 	region := parameters.Get("region")
 	limit := parameters.Get("limit")
 	logGroupNamePrefix := parameters.Get("logGroupNamePrefix")
 
-	logsClient, err := e.getCWLogsClient(ctx, pluginCtx, region)
+	logsClient, err := ds.getCWLogsClient(ctx, pluginCtx, region)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cloudwatch/resource_handler.go
+++ b/pkg/cloudwatch/resource_handler.go
@@ -12,22 +12,22 @@ import (
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 )
 
-func (e *cloudWatchExecutor) newResourceMux() *http.ServeMux {
+func (ds *DataSource) newResourceMux() *http.ServeMux {
 	mux := http.NewServeMux()
-	mux.HandleFunc("/ebs-volume-ids", handleResourceReq(e.handleGetEbsVolumeIds, e.logger))
-	mux.HandleFunc("/ec2-instance-attribute", handleResourceReq(e.handleGetEc2InstanceAttribute, e.logger))
-	mux.HandleFunc("/resource-arns", handleResourceReq(e.handleGetResourceArns, e.logger))
-	mux.HandleFunc("/log-groups", routes.ResourceRequestMiddleware(routes.LogGroupsHandler, e.logger, e.getRequestContext))
-	mux.HandleFunc("/metrics", routes.ResourceRequestMiddleware(routes.MetricsHandler, e.logger, e.getRequestContext))
-	mux.HandleFunc("/dimension-values", routes.ResourceRequestMiddleware(routes.DimensionValuesHandler, e.logger, e.getRequestContext))
-	mux.HandleFunc("/dimension-keys", routes.ResourceRequestMiddleware(routes.DimensionKeysHandler, e.logger, e.getRequestContext))
-	mux.HandleFunc("/accounts", routes.ResourceRequestMiddleware(routes.AccountsHandler, e.logger, e.getRequestContext))
-	mux.HandleFunc("/namespaces", routes.ResourceRequestMiddleware(routes.NamespacesHandler, e.logger, e.getRequestContext))
-	mux.HandleFunc("/log-group-fields", routes.ResourceRequestMiddleware(routes.LogGroupFieldsHandler, e.logger, e.getRequestContext))
-	mux.HandleFunc("/external-id", routes.ResourceRequestMiddleware(routes.ExternalIdHandler, e.logger, e.getRequestContextOnlySettings))
-	mux.HandleFunc("/regions", routes.ResourceRequestMiddleware(routes.RegionsHandler, e.logger, e.getRequestContext))
+	mux.HandleFunc("/ebs-volume-ids", handleResourceReq(ds.handleGetEbsVolumeIds, ds.logger))
+	mux.HandleFunc("/ec2-instance-attribute", handleResourceReq(ds.handleGetEc2InstanceAttribute, ds.logger))
+	mux.HandleFunc("/resource-arns", handleResourceReq(ds.handleGetResourceArns, ds.logger))
+	mux.HandleFunc("/log-groups", routes.ResourceRequestMiddleware(routes.LogGroupsHandler, ds.logger, ds.getRequestContext))
+	mux.HandleFunc("/metrics", routes.ResourceRequestMiddleware(routes.MetricsHandler, ds.logger, ds.getRequestContext))
+	mux.HandleFunc("/dimension-values", routes.ResourceRequestMiddleware(routes.DimensionValuesHandler, ds.logger, ds.getRequestContext))
+	mux.HandleFunc("/dimension-keys", routes.ResourceRequestMiddleware(routes.DimensionKeysHandler, ds.logger, ds.getRequestContext))
+	mux.HandleFunc("/accounts", routes.ResourceRequestMiddleware(routes.AccountsHandler, ds.logger, ds.getRequestContext))
+	mux.HandleFunc("/namespaces", routes.ResourceRequestMiddleware(routes.NamespacesHandler, ds.logger, ds.getRequestContext))
+	mux.HandleFunc("/log-group-fields", routes.ResourceRequestMiddleware(routes.LogGroupFieldsHandler, ds.logger, ds.getRequestContext))
+	mux.HandleFunc("/external-id", routes.ResourceRequestMiddleware(routes.ExternalIdHandler, ds.logger, ds.getRequestContextOnlySettings))
+	mux.HandleFunc("/regions", routes.ResourceRequestMiddleware(routes.RegionsHandler, ds.logger, ds.getRequestContext))
 	// remove this once AWS's Cross Account Observability is supported in GovCloud
-	mux.HandleFunc("/legacy-log-groups", handleResourceReq(e.handleGetLogGroups, e.logger))
+	mux.HandleFunc("/legacy-log-groups", handleResourceReq(ds.handleGetLogGroups, ds.logger))
 
 	return mux
 }

--- a/pkg/cloudwatch/response_parser.go
+++ b/pkg/cloudwatch/response_parser.go
@@ -19,7 +19,7 @@ import (
 // matches a dynamic label
 var dynamicLabel = regexp.MustCompile(`\$\{.+\}`)
 
-func (e *cloudWatchExecutor) parseResponse(ctx context.Context, metricDataOutputs []*cloudwatch.GetMetricDataOutput,
+func (ds *DataSource) parseResponse(ctx context.Context, metricDataOutputs []*cloudwatch.GetMetricDataOutput,
 	queries []*models.CloudWatchQuery) ([]*responseWrapper, error) {
 	aggregatedResponse := aggregateResponse(metricDataOutputs)
 	queriesById := map[string]*models.CloudWatchQuery{}


### PR DESCRIPTION
Most of the machinery of the executor is no longer needed with the move from `ProvideService` to `datasource.Manage`.