### PR TITLE
Remove unneeded pluginContext in resource handling

### DIFF
--- a/pkg/cloudwatch/annotation_query.go
+++ b/pkg/cloudwatch/annotation_query.go
@@ -23,7 +23,7 @@ type annotationEvent struct {
 	Text  string
 }
 
-func (ds *DataSource) executeAnnotationQuery(ctx context.Context, pluginCtx backend.PluginContext, model DataQueryJson, query backend.DataQuery) (*backend.QueryDataResponse, error) {
+func (ds *DataSource) executeAnnotationQuery(ctx context.Context, model DataQueryJson, query backend.DataQuery) (*backend.QueryDataResponse, error) {
 	result := backend.NewQueryDataResponse()
 	statistic := ""
 
@@ -52,7 +52,7 @@ func (ds *DataSource) executeAnnotationQuery(ctx context.Context, pluginCtx back
 	actionPrefix := model.ActionPrefix
 	alarmNamePrefix := model.AlarmNamePrefix
 
-	cli, err := ds.getCWClient(ctx, pluginCtx, model.Region)
+	cli, err := ds.getCWClient(ctx, model.Region)
 	if err != nil {
 		result.Responses[query.RefID] = backend.ErrorResponseWithErrorSource(fmt.Errorf("%v: %w", "failed to get client", err))
 		return result, nil

--- a/pkg/cloudwatch/log_actions.go
+++ b/pkg/cloudwatch/log_actions.go
@@ -57,7 +57,7 @@ func (ds *DataSource) executeLogActions(ctx context.Context, req *backend.QueryD
 
 		query := query
 		eg.Go(func() error {
-			dataframe, err := ds.executeLogAction(ectx, logsQuery, query, req.PluginContext)
+			dataframe, err := ds.executeLogAction(ectx, logsQuery, query)
 			if err != nil {
 				resultChan <- backend.Responses{
 					query.RefID: backend.ErrorResponseWithErrorSource(err),
@@ -94,18 +94,13 @@ func (ds *DataSource) executeLogActions(ctx context.Context, req *backend.QueryD
 	return resp, nil
 }
 
-func (ds *DataSource) executeLogAction(ctx context.Context, logsQuery models.LogsQuery, query backend.DataQuery, pluginCtx backend.PluginContext) (*data.Frame, error) {
-	instance, err := ds.getInstance(ctx, pluginCtx)
-	if err != nil {
-		return nil, err
-	}
-
-	region := instance.Settings.Region
+func (ds *DataSource) executeLogAction(ctx context.Context, logsQuery models.LogsQuery, query backend.DataQuery) (*data.Frame, error) {
+	region := ds.Settings.Region
 	if logsQuery.Region != "" {
 		region = logsQuery.Region
 	}
 
-	logsClient, err := ds.getCWLogsClient(ctx, pluginCtx, region)
+	logsClient, err := ds.getCWLogsClient(ctx, region)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cloudwatch/metric_find_query.go
+++ b/pkg/cloudwatch/metric_find_query.go
@@ -19,8 +19,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
 	"github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi"
 	resourcegroupstaggingapitypes "github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi/types"
-
-	"github.com/grafana/grafana-plugin-sdk-go/backend"
 )
 
 type suggestData struct {
@@ -43,12 +41,12 @@ func parseMultiSelectValue(input string) []string {
 	return []string{trimmedInput}
 }
 
-func (ds *DataSource) handleGetEbsVolumeIds(ctx context.Context, pluginCtx backend.PluginContext, parameters url.Values) ([]suggestData, error) {
+func (ds *DataSource) handleGetEbsVolumeIds(ctx context.Context, parameters url.Values) ([]suggestData, error) {
 	region := parameters.Get("region")
 	instanceId := parameters.Get("instanceId")
 
 	instanceIds := parseMultiSelectValue(instanceId)
-	instances, err := ds.ec2DescribeInstances(ctx, pluginCtx, region, nil, instanceIds)
+	instances, err := ds.ec2DescribeInstances(ctx, region, nil, instanceIds)
 	if err != nil {
 		return nil, err
 	}
@@ -65,7 +63,7 @@ func (ds *DataSource) handleGetEbsVolumeIds(ctx context.Context, pluginCtx backe
 	return result, nil
 }
 
-func (ds *DataSource) handleGetEc2InstanceAttribute(ctx context.Context, pluginCtx backend.PluginContext, parameters url.Values) ([]suggestData, error) {
+func (ds *DataSource) handleGetEc2InstanceAttribute(ctx context.Context, parameters url.Values) ([]suggestData, error) {
 	region := parameters.Get("region")
 	attributeName := parameters.Get("attributeName")
 	filterJson := parameters.Get("filters")
@@ -92,7 +90,7 @@ func (ds *DataSource) handleGetEc2InstanceAttribute(ctx context.Context, pluginC
 		}
 	}
 
-	instances, err := ds.ec2DescribeInstances(ctx, pluginCtx, region, filters, nil)
+	instances, err := ds.ec2DescribeInstances(ctx, region, filters, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -177,7 +175,7 @@ func getInstanceAttributeValue(attributeName string, instance ec2types.Instance)
 	return data, true, nil
 }
 
-func (ds *DataSource) handleGetResourceArns(ctx context.Context, pluginCtx backend.PluginContext, parameters url.Values) ([]suggestData, error) {
+func (ds *DataSource) handleGetResourceArns(ctx context.Context, parameters url.Values) ([]suggestData, error) {
 	region := parameters.Get("region")
 	resourceType := parameters.Get("resourceType")
 	tagsJson := parameters.Get("tags")
@@ -206,7 +204,7 @@ func (ds *DataSource) handleGetResourceArns(ctx context.Context, pluginCtx backe
 
 	resourceTypes := []string{resourceType}
 
-	resources, err := ds.resourceGroupsGetResources(ctx, pluginCtx, region, filters, resourceTypes)
+	resources, err := ds.resourceGroupsGetResources(ctx, region, filters, resourceTypes)
 	if err != nil {
 		return nil, err
 	}
@@ -220,13 +218,13 @@ func (ds *DataSource) handleGetResourceArns(ctx context.Context, pluginCtx backe
 	return result, nil
 }
 
-func (ds *DataSource) ec2DescribeInstances(ctx context.Context, pluginCtx backend.PluginContext, region string, filters []ec2types.Filter, instanceIds []string) (*ec2.DescribeInstancesOutput, error) {
+func (ds *DataSource) ec2DescribeInstances(ctx context.Context, region string, filters []ec2types.Filter, instanceIds []string) (*ec2.DescribeInstancesOutput, error) {
 	params := &ec2.DescribeInstancesInput{
 		Filters:     filters,
 		InstanceIds: instanceIds,
 	}
 
-	client, err := ds.getEC2Client(ctx, pluginCtx, region)
+	client, err := ds.getEC2Client(ctx, region)
 	if err != nil {
 		return nil, err
 	}
@@ -243,14 +241,14 @@ func (ds *DataSource) ec2DescribeInstances(ctx context.Context, pluginCtx backen
 	return resp, nil
 }
 
-func (ds *DataSource) resourceGroupsGetResources(ctx context.Context, pluginCtx backend.PluginContext, region string, filters []resourcegroupstaggingapitypes.TagFilter,
+func (ds *DataSource) resourceGroupsGetResources(ctx context.Context, region string, filters []resourcegroupstaggingapitypes.TagFilter,
 	resourceTypes []string) (*resourcegroupstaggingapi.GetResourcesOutput, error) {
 	params := &resourcegroupstaggingapi.GetResourcesInput{
 		ResourceTypeFilters: resourceTypes,
 		TagFilters:          filters,
 	}
 
-	client, err := ds.getRGTAClient(ctx, pluginCtx, region)
+	client, err := ds.getRGTAClient(ctx, region)
 	if err != nil {
 		return nil, err
 	}
@@ -269,12 +267,12 @@ func (ds *DataSource) resourceGroupsGetResources(ctx context.Context, pluginCtx 
 }
 
 // legacy route, will be removed once GovCloud supports Cross Account Observability
-func (ds *DataSource) handleGetLogGroups(ctx context.Context, pluginCtx backend.PluginContext, parameters url.Values) ([]suggestData, error) {
+func (ds *DataSource) handleGetLogGroups(ctx context.Context, parameters url.Values) ([]suggestData, error) {
 	region := parameters.Get("region")
 	limit := parameters.Get("limit")
 	logGroupNamePrefix := parameters.Get("logGroupNamePrefix")
 
-	logsClient, err := ds.getCWLogsClient(ctx, pluginCtx, region)
+	logsClient, err := ds.getCWLogsClient(ctx, region)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cloudwatch/models/api.go
+++ b/pkg/cloudwatch/models/api.go
@@ -10,13 +10,12 @@ import (
 	"github.com/aws/aws-sdk-go-v2/service/oam"
 
 	"github.com/grafana/grafana-cloudwatch-datasource/pkg/cloudwatch/models/resources"
-	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 )
 
-type RequestContextFactoryFunc func(ctx context.Context, pluginCtx backend.PluginContext, region string) (reqCtx RequestContext, err error)
+type RequestContextFactoryFunc func(ctx context.Context, region string) (reqCtx RequestContext, err error)
 
-type RouteHandlerFunc func(ctx context.Context, pluginCtx backend.PluginContext, reqContextFactory RequestContextFactoryFunc, parameters url.Values) ([]byte, *HttpError)
+type RouteHandlerFunc func(ctx context.Context, reqContextFactory RequestContextFactoryFunc, parameters url.Values) ([]byte, *HttpError)
 
 type RequestContext struct {
 	MetricsClientProvider  MetricsClientProvider

--- a/pkg/cloudwatch/resource_handler.go
+++ b/pkg/cloudwatch/resource_handler.go
@@ -8,7 +8,6 @@ import (
 	"net/url"
 
 	"github.com/grafana/grafana-cloudwatch-datasource/pkg/cloudwatch/routes"
-	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 )
 
@@ -32,18 +31,17 @@ func (ds *DataSource) newResourceMux() *http.ServeMux {
 	return mux
 }
 
-type handleFn func(ctx context.Context, pluginCtx backend.PluginContext, parameters url.Values) ([]suggestData, error)
+type handleFn func(ctx context.Context, parameters url.Values) ([]suggestData, error)
 
 func handleResourceReq(handleFunc handleFn, logger log.Logger) func(rw http.ResponseWriter, req *http.Request) {
 	return func(rw http.ResponseWriter, req *http.Request) {
 		ctx := req.Context()
-		pluginContext := backend.PluginConfigFromContext(ctx)
 		err := req.ParseForm()
 		if err != nil {
 			writeResponse(rw, http.StatusBadRequest, fmt.Sprintf("unexpected error %v", err), logger.FromContext(ctx))
 			return
 		}
-		data, err := handleFunc(ctx, pluginContext, req.URL.Query())
+		data, err := handleFunc(ctx, req.URL.Query())
 		if err != nil {
 			writeResponse(rw, http.StatusBadRequest, fmt.Sprintf("unexpected error %v", err), logger.FromContext(ctx))
 			return

--- a/pkg/cloudwatch/routes/accounts.go
+++ b/pkg/cloudwatch/routes/accounts.go
@@ -10,16 +10,15 @@ import (
 
 	"github.com/grafana/grafana-cloudwatch-datasource/pkg/cloudwatch/models"
 	"github.com/grafana/grafana-cloudwatch-datasource/pkg/cloudwatch/services"
-	"github.com/grafana/grafana-plugin-sdk-go/backend"
 )
 
-func AccountsHandler(ctx context.Context, pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, parameters url.Values) ([]byte, *models.HttpError) {
+func AccountsHandler(ctx context.Context, reqCtxFactory models.RequestContextFactoryFunc, parameters url.Values) ([]byte, *models.HttpError) {
 	region := parameters.Get("region")
 	if region == "" {
 		return nil, models.NewHttpError("error in AccountsHandler", http.StatusBadRequest, fmt.Errorf("region is required"))
 	}
 
-	service, err := newAccountsService(ctx, pluginCtx, reqCtxFactory, region)
+	service, err := newAccountsService(ctx, reqCtxFactory, region)
 	if err != nil {
 		return nil, models.NewHttpError("error in AccountsHandler", http.StatusInternalServerError, err)
 	}
@@ -46,8 +45,8 @@ func AccountsHandler(ctx context.Context, pluginCtx backend.PluginContext, reqCt
 // newAccountService is an account service factory.
 //
 // Stubbable by tests.
-var newAccountsService = func(ctx context.Context, pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.AccountsProvider, error) {
-	oamClient, err := reqCtxFactory(ctx, pluginCtx, region)
+var newAccountsService = func(ctx context.Context, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.AccountsProvider, error) {
+	oamClient, err := reqCtxFactory(ctx, region)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cloudwatch/routes/dimension_keys.go
+++ b/pkg/cloudwatch/routes/dimension_keys.go
@@ -9,16 +9,15 @@ import (
 	"github.com/grafana/grafana-cloudwatch-datasource/pkg/cloudwatch/models"
 	"github.com/grafana/grafana-cloudwatch-datasource/pkg/cloudwatch/models/resources"
 	"github.com/grafana/grafana-cloudwatch-datasource/pkg/cloudwatch/services"
-	"github.com/grafana/grafana-plugin-sdk-go/backend"
 )
 
-func DimensionKeysHandler(ctx context.Context, pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, parameters url.Values) ([]byte, *models.HttpError) {
+func DimensionKeysHandler(ctx context.Context, reqCtxFactory models.RequestContextFactoryFunc, parameters url.Values) ([]byte, *models.HttpError) {
 	dimensionKeysRequest, err := resources.GetDimensionKeysRequest(parameters)
 	if err != nil {
 		return nil, models.NewHttpError("error in DimensionKeyHandler", http.StatusBadRequest, err)
 	}
 
-	service, err := newListMetricsService(ctx, pluginCtx, reqCtxFactory, dimensionKeysRequest.Region)
+	service, err := newListMetricsService(ctx, reqCtxFactory, dimensionKeysRequest.Region)
 	if err != nil {
 		return nil, models.NewHttpError("error in DimensionKeyHandler", http.StatusInternalServerError, err)
 	}
@@ -45,8 +44,8 @@ func DimensionKeysHandler(ctx context.Context, pluginCtx backend.PluginContext, 
 // newListMetricsService is an list metrics service factory.
 //
 // Stubbable by tests.
-var newListMetricsService = func(ctx context.Context, pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.ListMetricsProvider, error) {
-	metricClient, err := reqCtxFactory(ctx, pluginCtx, region)
+var newListMetricsService = func(ctx context.Context, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.ListMetricsProvider, error) {
+	metricClient, err := reqCtxFactory(ctx, region)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cloudwatch/routes/dimension_values.go
+++ b/pkg/cloudwatch/routes/dimension_values.go
@@ -8,16 +8,15 @@ import (
 
 	"github.com/grafana/grafana-cloudwatch-datasource/pkg/cloudwatch/models"
 	"github.com/grafana/grafana-cloudwatch-datasource/pkg/cloudwatch/models/resources"
-	"github.com/grafana/grafana-plugin-sdk-go/backend"
 )
 
-func DimensionValuesHandler(ctx context.Context, pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, parameters url.Values) ([]byte, *models.HttpError) {
+func DimensionValuesHandler(ctx context.Context, reqCtxFactory models.RequestContextFactoryFunc, parameters url.Values) ([]byte, *models.HttpError) {
 	dimensionValuesRequest, err := resources.GetDimensionValuesRequest(parameters)
 	if err != nil {
 		return nil, models.NewHttpError("error in DimensionValuesHandler", http.StatusBadRequest, err)
 	}
 
-	service, err := newListMetricsService(ctx, pluginCtx, reqCtxFactory, dimensionValuesRequest.Region)
+	service, err := newListMetricsService(ctx, reqCtxFactory, dimensionValuesRequest.Region)
 	if err != nil {
 		return nil, models.NewHttpError("error in DimensionValuesHandler", http.StatusInternalServerError, err)
 	}

--- a/pkg/cloudwatch/routes/external_id.go
+++ b/pkg/cloudwatch/routes/external_id.go
@@ -7,15 +7,14 @@ import (
 	"net/url"
 
 	"github.com/grafana/grafana-cloudwatch-datasource/pkg/cloudwatch/models"
-	"github.com/grafana/grafana-plugin-sdk-go/backend"
 )
 
 type ExternalIdResponse struct {
 	ExternalId string `json:"externalId"`
 }
 
-func ExternalIdHandler(ctx context.Context, pluginCtx backend.PluginContext, reqCtxBeforeAuth models.RequestContextFactoryFunc, parameters url.Values) ([]byte, *models.HttpError) {
-	reqCtx, err := reqCtxBeforeAuth(ctx, pluginCtx, "")
+func ExternalIdHandler(ctx context.Context, reqCtxBeforeAuth models.RequestContextFactoryFunc, parameters url.Values) ([]byte, *models.HttpError) {
+	reqCtx, err := reqCtxBeforeAuth(ctx, "")
 	if err != nil {
 		return nil, models.NewHttpError("error in ExternalIdHandler", http.StatusInternalServerError, err)
 	}

--- a/pkg/cloudwatch/routes/log_group_fields.go
+++ b/pkg/cloudwatch/routes/log_group_fields.go
@@ -8,16 +8,15 @@ import (
 
 	"github.com/grafana/grafana-cloudwatch-datasource/pkg/cloudwatch/models"
 	"github.com/grafana/grafana-cloudwatch-datasource/pkg/cloudwatch/models/resources"
-	"github.com/grafana/grafana-plugin-sdk-go/backend"
 )
 
-func LogGroupFieldsHandler(ctx context.Context, pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, parameters url.Values) ([]byte, *models.HttpError) {
+func LogGroupFieldsHandler(ctx context.Context, reqCtxFactory models.RequestContextFactoryFunc, parameters url.Values) ([]byte, *models.HttpError) {
 	request, err := resources.ParseLogGroupFieldsRequest(parameters)
 	if err != nil {
 		return nil, models.NewHttpError("error in LogGroupFieldsHandler", http.StatusBadRequest, err)
 	}
 
-	service, err := newLogGroupsService(ctx, pluginCtx, reqCtxFactory, request.Region)
+	service, err := newLogGroupsService(ctx, reqCtxFactory, request.Region)
 	if err != nil {
 		return nil, models.NewHttpError("newLogGroupsService error", http.StatusInternalServerError, err)
 	}

--- a/pkg/cloudwatch/routes/log_groups.go
+++ b/pkg/cloudwatch/routes/log_groups.go
@@ -10,16 +10,15 @@ import (
 	"github.com/grafana/grafana-cloudwatch-datasource/pkg/cloudwatch/models"
 	"github.com/grafana/grafana-cloudwatch-datasource/pkg/cloudwatch/models/resources"
 	"github.com/grafana/grafana-cloudwatch-datasource/pkg/cloudwatch/services"
-	"github.com/grafana/grafana-plugin-sdk-go/backend"
 )
 
-func LogGroupsHandler(ctx context.Context, pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, parameters url.Values) ([]byte, *models.HttpError) {
+func LogGroupsHandler(ctx context.Context, reqCtxFactory models.RequestContextFactoryFunc, parameters url.Values) ([]byte, *models.HttpError) {
 	request, err := resources.ParseLogGroupsRequest(parameters)
 	if err != nil {
 		return nil, models.NewHttpError("cannot set both log group name prefix and pattern", http.StatusBadRequest, err)
 	}
 
-	service, err := newLogGroupsService(ctx, pluginCtx, reqCtxFactory, request.Region)
+	service, err := newLogGroupsService(ctx, reqCtxFactory, request.Region)
 	if err != nil {
 		return nil, models.NewHttpError("newLogGroupsService error", http.StatusInternalServerError, err)
 	}
@@ -40,8 +39,8 @@ func LogGroupsHandler(ctx context.Context, pluginCtx backend.PluginContext, reqC
 // newLogGroupsService is a describe log groups service factory.
 //
 // Stubbable by tests.
-var newLogGroupsService = func(ctx context.Context, pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.LogGroupsProvider, error) {
-	reqCtx, err := reqCtxFactory(ctx, pluginCtx, region)
+var newLogGroupsService = func(ctx context.Context, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.LogGroupsProvider, error) {
+	reqCtx, err := reqCtxFactory(ctx, region)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/cloudwatch/routes/metrics.go
+++ b/pkg/cloudwatch/routes/metrics.go
@@ -9,16 +9,15 @@ import (
 	"github.com/grafana/grafana-cloudwatch-datasource/pkg/cloudwatch/models"
 	"github.com/grafana/grafana-cloudwatch-datasource/pkg/cloudwatch/models/resources"
 	"github.com/grafana/grafana-cloudwatch-datasource/pkg/cloudwatch/services"
-	"github.com/grafana/grafana-plugin-sdk-go/backend"
 )
 
-func MetricsHandler(ctx context.Context, pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, parameters url.Values) ([]byte, *models.HttpError) {
+func MetricsHandler(ctx context.Context, reqCtxFactory models.RequestContextFactoryFunc, parameters url.Values) ([]byte, *models.HttpError) {
 	metricsRequest, err := resources.GetMetricsRequest(parameters)
 	if err != nil {
 		return nil, models.NewHttpError("error in MetricsHandler", http.StatusBadRequest, err)
 	}
 
-	service, err := newListMetricsService(ctx, pluginCtx, reqCtxFactory, metricsRequest.Region)
+	service, err := newListMetricsService(ctx, reqCtxFactory, metricsRequest.Region)
 	if err != nil {
 		return nil, models.NewHttpError("error in MetricsHandler", http.StatusInternalServerError, err)
 	}

--- a/pkg/cloudwatch/routes/middleware.go
+++ b/pkg/cloudwatch/routes/middleware.go
@@ -3,7 +3,6 @@ package routes
 import (
 	"net/http"
 
-	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/backend/log"
 
 	"github.com/grafana/grafana-cloudwatch-datasource/pkg/cloudwatch/models"
@@ -17,8 +16,7 @@ func ResourceRequestMiddleware(handleFunc models.RouteHandlerFunc, logger log.Lo
 		}
 
 		ctx := req.Context()
-		pluginContext := backend.PluginConfigFromContext(ctx)
-		json, httpError := handleFunc(ctx, pluginContext, reqCtxFactory, req.URL.Query())
+		json, httpError := handleFunc(ctx, reqCtxFactory, req.URL.Query())
 		if httpError != nil {
 			logger.FromContext(ctx).Error("Error handling resource request", "error", httpError.Message)
 			respondWithError(rw, httpError)

--- a/pkg/cloudwatch/routes/namespaces.go
+++ b/pkg/cloudwatch/routes/namespaces.go
@@ -11,11 +11,10 @@ import (
 	"github.com/grafana/grafana-cloudwatch-datasource/pkg/cloudwatch/models"
 	"github.com/grafana/grafana-cloudwatch-datasource/pkg/cloudwatch/models/resources"
 	"github.com/grafana/grafana-cloudwatch-datasource/pkg/cloudwatch/services"
-	"github.com/grafana/grafana-plugin-sdk-go/backend"
 )
 
-func NamespacesHandler(ctx context.Context, pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, _ url.Values) ([]byte, *models.HttpError) {
-	reqCtx, err := reqCtxFactory(ctx, pluginCtx, "default")
+func NamespacesHandler(ctx context.Context, reqCtxFactory models.RequestContextFactoryFunc, _ url.Values) ([]byte, *models.HttpError) {
+	reqCtx, err := reqCtxFactory(ctx, "default")
 	if err != nil {
 		return nil, models.NewHttpError("error in NamespacesHandler", http.StatusInternalServerError, err)
 	}

--- a/pkg/cloudwatch/routes/regions.go
+++ b/pkg/cloudwatch/routes/regions.go
@@ -9,15 +9,14 @@ import (
 
 	"github.com/grafana/grafana-cloudwatch-datasource/pkg/cloudwatch/models"
 	"github.com/grafana/grafana-cloudwatch-datasource/pkg/cloudwatch/services"
-	"github.com/grafana/grafana-plugin-sdk-go/backend"
 )
 
 const (
 	defaultRegion = "default"
 )
 
-func RegionsHandler(ctx context.Context, pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, parameters url.Values) ([]byte, *models.HttpError) {
-	service, err := newRegionsService(ctx, pluginCtx, reqCtxFactory, defaultRegion)
+func RegionsHandler(ctx context.Context, reqCtxFactory models.RequestContextFactoryFunc, parameters url.Values) ([]byte, *models.HttpError) {
+	service, err := newRegionsService(ctx, reqCtxFactory, defaultRegion)
 	if err != nil {
 		if errors.Is(err, models.ErrMissingRegion) {
 			return nil, models.NewHttpError("Error in Regions Handler when connecting to aws without a default region selection", http.StatusBadRequest, err)
@@ -38,8 +37,8 @@ func RegionsHandler(ctx context.Context, pluginCtx backend.PluginContext, reqCtx
 	return regionsResponse, nil
 }
 
-var newRegionsService = func(ctx context.Context, pluginCtx backend.PluginContext, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.RegionsAPIProvider, error) {
-	reqCtx, err := reqCtxFactory(ctx, pluginCtx, region)
+var newRegionsService = func(ctx context.Context, reqCtxFactory models.RequestContextFactoryFunc, region string) (models.RegionsAPIProvider, error) {
+	reqCtx, err := reqCtxFactory(ctx, region)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
When cloudWatchExecutor had its own instanceManager the pluginContext was necessary to get the right DataSource instance, but this is now managed by grafana-plugin-sdk-go's `datasource.Manage`.