### PR TITLE
Add Frametype to Metrics response

### DIFF
--- a/pkg/cloudwatch/response_parser.go
+++ b/pkg/cloudwatch/response_parser.go
@@ -248,6 +248,7 @@ func buildDataFrames(ctx context.Context, aggregatedResponse models.QueryRowResp
 			RefID: query.RefId,
 			Meta:  createMeta(query),
 		}
+		frame.Meta.Type = data.FrameTypeTimeSeriesMulti
 
 		for code := range aggregatedResponse.ErrorCodes {
 			if aggregatedResponse.ErrorCodes[code] {


### PR DESCRIPTION
Originally in https://github.com/grafana/grafana/pull/103617

**What is this feature?**

Adds the Frame Type to Metrics responses.

**Why do we need this feature?**

Enables compatibility with SQL Expressions.

**Who is this feature for?**

[Add information on what kind of user the feature is for.]

**Which issue(s) does this PR fix?**:

<!--

- Automatically closes linked issue when the Pull Request is merged.

Usage: "Fixes #<issue number>", or "Fixes (paste link of issue)"

-->

Fixes #[103196](https://github.com/grafana/grafana/issues/103196)

**Special notes for your reviewer:**

 - I haven't set `FrameTypeVersion`, this would change the code path for other Server side expression operations, where as only setting the type for SSE will only impact the SQL operation 
 - I haven't tried this yet since I don't have CW set up locally, hoping someone from the AWS DS squad can take this over.
