### PR TITLE
Prepare 12.0.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 12.0.1
+
+- Fix: Bump grafana-aws-sdk for v2 auth fix in [#14](https://github.com/grafana/grafana-cloudwatch-datasource/pull/14)
+
 ## 12.0.0
 
  - Initial release

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-cloudwatch-datasource",
-  "version": "12.0.0",
+  "version": "12.0.1",
   "scripts": {
     "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",
     "dev": "webpack -w -c ./.config/webpack/webpack.config.ts --env development",


### PR DESCRIPTION
## 12.0.1

- Fix: Bump grafana-aws-sdk for v2 auth fix in [#14](https://github.com/grafana/grafana-cloudwatch-datasource/pull/14)