### PR TITLE
Externalization: Fix runtime jsx configuration

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "grafana-cloudwatch-datasource",
   "version": "12.0.1",
   "scripts": {
-    "build": "webpack -c ./.config/webpack/webpack.config.ts --env production",
-    "dev": "webpack -w -c ./.config/webpack/webpack.config.ts --env development",
+    "build": "webpack -c ./webpack.config.ts --env production",
+    "dev": "webpack -w -c ./webpack.config.ts --env development",
     "test": "jest --watch --onlyChanged",
     "test:ci": "jest --passWithNoTests --maxWorkers 4",
     "typecheck": "tsc --noEmit",

--- a/pkg/cloudwatch/cloudwatch.go
+++ b/pkg/cloudwatch/cloudwatch.go
@@ -95,7 +95,7 @@ func NewDatasource(ctx context.Context, settings backend.DataSourceInstanceSetti
 		return nil, err
 	}
 
-	ds := DataSource{
+	ds := &DataSource{
 		Settings: instanceSettings,
 		// this is used to build a custom dialer when secure socks proxy is enabled
 		ProxyOpts:         opts.ProxyOptions,

--- a/pkg/cloudwatch/cloudwatch_test.go
+++ b/pkg/cloudwatch/cloudwatch_test.go
@@ -31,7 +31,7 @@ func TestNewInstanceSettings(t *testing.T) {
 		name       string
 		settings   backend.DataSourceInstanceSettings
 		settingCtx context.Context
-		expectedDS DataSource
+		expectedDS *DataSource
 		Err        require.ErrorAssertionFunc
 	}{
 		{
@@ -59,7 +59,7 @@ func TestNewInstanceSettings(t *testing.T) {
 				awsds.ListMetricsPageLimitKeyName:        "50",
 				proxy.PluginSecureSocksProxyEnabled:      "true",
 			})),
-			expectedDS: DataSource{
+			expectedDS: &DataSource{
 				Settings: models.CloudWatchSettings{
 					AWSDatasourceSettings: awsds.AWSDatasourceSettings{
 						Profile:       "foo",
@@ -89,10 +89,10 @@ func TestNewInstanceSettings(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			instance, err := NewDatasource(tt.settingCtx, tt.settings)
-			ds := instance.(DataSource)
+			ds := instance.(*DataSource)
 			tt.Err(t, err)
 			assert.Equal(t, tt.expectedDS.Settings.GrafanaSettings, ds.Settings.GrafanaSettings)
-			datasourceComparer := cmp.Comparer(func(d1 DataSource, d2 DataSource) bool {
+			datasourceComparer := cmp.Comparer(func(d1 *DataSource, d2 *DataSource) bool {
 				return d1.Settings.Profile == d2.Settings.Profile &&
 					d1.Settings.Region == d2.Settings.Region &&
 					d1.Settings.AuthType == d2.Settings.AuthType &&
@@ -103,7 +103,7 @@ func TestNewInstanceSettings(t *testing.T) {
 					d1.Settings.AccessKey == d2.Settings.AccessKey &&
 					d1.Settings.SecretKey == d2.Settings.SecretKey
 			})
-			if !cmp.Equal(instance.(DataSource), tt.expectedDS, datasourceComparer) {
+			if !cmp.Equal(instance.(*DataSource), tt.expectedDS, datasourceComparer) {
 				t.Errorf("Unexpected result. Expecting\n%v \nGot:\n%v", instance, tt.expectedDS)
 			}
 		})

--- a/src/datasource.test.ts
+++ b/src/datasource.test.ts
@@ -25,6 +25,13 @@ import {
 } from './types';
 import * as templateUtils from './utils/templateVariableUtils';
 
+jest.mock('./utils/templateVariableUtils', () => {
+  return {
+    __esModule: true, // getting 'cannot redefine getVariableName' otherwise
+    ...jest.requireActual('./utils/templateVariableUtils')
+  };
+});
+
 describe('datasource', () => {
   beforeEach(() => {
     jest.clearAllMocks();

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -1,0 +1,48 @@
+import type { Configuration } from 'webpack';
+import { merge } from 'webpack-merge';
+import grafanaConfig from './.config/webpack/webpack.config';
+import path from 'path';
+import { SOURCE_DIR } from './.config/webpack/constants';
+
+const config = async (env): Promise<Configuration> => {
+  const baseConfig = await grafanaConfig(env);
+
+  return merge(baseConfig, {
+    module: {
+      ...baseConfig.module,
+      rules: [
+        ...(baseConfig.module?.rules || []),
+        {
+          exclude: /(node_modules)/,
+          test: /\.[tj]sx?$/,
+          use: {
+            loader: 'swc-loader',
+            options: {
+              jsc: {
+                baseUrl: path.resolve(process.cwd(), SOURCE_DIR),
+                target: 'es2015',
+                loose: false,
+                parser: {
+                  syntax: 'typescript',
+                  tsx: true,
+                  decorators: false,
+                  dynamicImport: true,
+                },
+                transform: {
+                  react: {
+                    runtime: 'automatic',
+                  },
+                },
+              },
+            },
+          },
+        },
+      ],
+    },
+    output: {
+      asyncChunks: true,
+    },
+  });
+};
+
+export default config;


### PR DESCRIPTION
We're getting "react not defined", so we should overrride the swc loader rule from the base config to include runtime: automatic