### PR TITLE
Prepare 12.0.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 12.0.2
+
+- Externalization: Fix runtime jsx configuration in [#18](https://github.com/grafana/grafana-cloudwatch-datasource/pull/18)
+
 ## 12.0.1
 
 - Fix: Bump grafana-aws-sdk for v2 auth fix in [#14](https://github.com/grafana/grafana-cloudwatch-datasource/pull/14)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-cloudwatch-datasource",
-  "version": "12.0.1",
+  "version": "12.0.2",
   "scripts": {
     "build": "webpack -c ./webpack.config.ts --env production",
     "dev": "webpack -w -c ./webpack.config.ts --env development",


### PR DESCRIPTION
## 12.0.2

- Externalization: Fix runtime jsx configuration in [#18](https://github.com/grafana/grafana-cloudwatch-datasource/pull/18)