### PR TITLE
Add support for auto-merging dependabot updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,5 +1,4 @@
 version: 2
-enable-beta-ecosystems: true
 updates:
   - package-ecosystem: 'gomod'
     directory: '/'
@@ -13,6 +12,8 @@ updates:
     directory: '/'
     schedule:
       interval: 'daily'
+    cooldown:
+      default-days: 7
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,12 +8,16 @@ updates:
       semver-major-days: 30
       semver-minor-days: 14
       semver-patch-days: 7
+      exclude:
+        - 'github.com/grafana/*'
   - package-ecosystem: 'github-actions'
     directory: '/'
     schedule:
       interval: 'daily'
     cooldown:
       default-days: 7
+      exclude:
+        - 'grafana/*'
   - package-ecosystem: 'npm'
     directory: '/'
     schedule:
@@ -22,6 +26,8 @@ updates:
       semver-major-days: 30
       semver-minor-days: 14
       semver-patch-days: 7
+      exclude:
+        - '@grafana/*'
     groups:
       grafana-dependencies:
         patterns:

--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,36 +1,48 @@
-# To get started with Dependabot version updates, you'll need to specify which
-# package ecosystems to update and where the package manifests are located.
-# Please see the documentation for all configuration options:
-# https://docs.github.com/github/administering-a-repository/configuration-options-for-dependency-updates
-
 version: 2
+enable-beta-ecosystems: true
 updates:
-  - package-ecosystem: 'github-actions'
-    directory: '/'
-    schedule:
-      interval: 'weekly'
-    groups:
-      all-github-action-dependencies:
-        patterns:
-          - '*'
-  - package-ecosystem: 'npm'
-    directory: '/'
-    schedule:
-      interval: 'weekly'
-    ignore: 
-      - dependency-name: 'react'
-        update-types: ["version-update:semver-major"]
-      - dependency-name: 'react-dom'
-        update-types: ["version-update:semver-major"]
-    groups:
-      all-node-dependencies:
-        patterns:
-          - '*'
   - package-ecosystem: 'gomod'
     directory: '/'
     schedule:
-      interval: 'weekly'
+      interval: 'daily'
+    cooldown:
+      semver-major-days: 30
+      semver-minor-days: 14
+      semver-patch-days: 7
+  - package-ecosystem: 'github-actions'
+    directory: '/'
+    schedule:
+      interval: 'daily'
+  - package-ecosystem: 'npm'
+    directory: '/'
+    schedule:
+      interval: 'daily'
+    cooldown:
+      semver-major-days: 30
+      semver-minor-days: 14
+      semver-patch-days: 7
     groups:
-      all-go-dependencies:
+      grafana-dependencies:
         patterns:
-          - '*'
+          - '@grafana/data'
+          - '@grafana/runtime'
+          - '@grafana/schema'
+          - '@grafana/ui'
+
+    # Ignore dependencies that need to be updated manually for compatibility reasons
+    ignore:
+      # Keep @types/node in sync with the node version in .nvmrc
+      - dependency-name: '@types/node'
+        update-types: ['version-update:semver-major']
+      # Keep react and react-dom on the same major version used by Grafana
+      - dependency-name: react
+        update-types: ['version-update:semver-major']
+      - dependency-name: react-dom
+        update-types: ['version-update:semver-major']
+      # Keep react-router-dom and react-router-dom-v5-compat on the same compatible major version used by Grafana
+      - dependency-name: react-router-dom
+        update-types: ['version-update:semver-major']
+      - dependency-name: react-router-dom-v5-compat
+        update-types: ['version-update:semver-major']
+      # Keep rxjs in sync with the version used by `@grafana/*` packages
+      - dependency-name: rxjs

--- a/.github/workflows/dependabot-reviewer.yml
+++ b/.github/workflows/dependabot-reviewer.yml
@@ -1,0 +1,12 @@
+name: Dependabot reviewer
+on: pull_request
+permissions:
+  pull-requests: write
+  contents: write
+jobs:
+  call-workflow-passing-data:
+    uses: grafana/security-github-actions/.github/workflows/dependabot-automerge.yaml@main
+    with:
+      packages-minor-autoupdate: '["@emotion/css","@grafana/aws-sdk","@grafana/data","@grafana/plugin-ui","@grafana/runtime","@grafana/scenes","@grafana/schema","@grafana/ui","common-tags","jsurl","github.com/aws/aws-sdk-go-v2","github.com/aws/aws-sdk-go-v2/service/cloudwatch","github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs","github.com/aws/aws-sdk-go-v2/service/ec2","github.com/aws/aws-sdk-go-v2/service/oam","github.com/aws/aws-sdk-go-v2/service/resourcegroupstaggingapi","github.com/aws/smithy-go","github.com/go-stack/stack","github.com/google/go-cmp","github.com/google/uuid","github.com/grafana/grafana-aws-sdk","github.com/grafana/grafana-plugin-sdk-go","github.com/patrickmn/go-cache","github.com/prometheus/client_golang","github.com/stretchr/testify","golang.org/x/sync"]'
+      repository-merge-method: 'squash'
+


### PR DESCRIPTION
Changes:
- Adds support for the cooldown feature for the github-actions, go and npm ecosystems in `.github/dependabot.yml`. https://docs.github.com/en/code-security/dependabot/working-with-dependabot/dependabot-options-reference#cooldown-
- Uses the existing workflow to automerge dependabot updates https://github.com/grafana/security-github-actions/blob/main/.github/workflows/dependabot-automerge.yaml