### PR TITLE
Add syntax highlighting and autocomplete for logs diff command

### DIFF
--- a/src/__mocks__/cloudwatch-logs-test-data/diffModifierQuery.ts
+++ b/src/__mocks__/cloudwatch-logs-test-data/diffModifierQuery.ts
@@ -1,0 +1,4 @@
+export const diffModifierQuery = {
+  query: `pattern @message | diff previous`,
+  position: { lineNumber: 1, column: 32 },
+};

--- a/src/__mocks__/cloudwatch-logs-test-data/diffQuery.ts
+++ b/src/__mocks__/cloudwatch-logs-test-data/diffQuery.ts
@@ -1,0 +1,4 @@
+export const diffQuery = {
+  query: `pattern @message | diff `,
+  position: { lineNumber: 1, column: 24 },
+};

--- a/src/__mocks__/cloudwatch-logs-test-data/index.ts
+++ b/src/__mocks__/cloudwatch-logs-test-data/index.ts
@@ -6,3 +6,5 @@ export { multiLineFullQuery } from './multiLineFullQuery';
 export { filterQuery } from './filterQuery';
 export { newCommandQuery } from './newCommandQuery';
 export { sortQuery } from './sortQuery';
+export { diffQuery } from './diffQuery';
+export { diffModifierQuery } from './diffModifierQuery';

--- a/src/language/logs/completion/CompletionItemProvider.test.ts
+++ b/src/language/logs/completion/CompletionItemProvider.test.ts
@@ -4,12 +4,19 @@ import { CustomVariableModel } from '@grafana/data';
 import { monacoTypes } from '@grafana/ui';
 
 import { setupMockedTemplateService, logGroupNamesVariable } from '../../../__mocks__/CloudWatchDataSource';
-import { emptyQuery, filterQuery, newCommandQuery, sortQuery } from '../../../__mocks__/cloudwatch-logs-test-data';
+import {
+  diffQuery,
+  diffModifierQuery,
+  emptyQuery,
+  filterQuery,
+  newCommandQuery,
+  sortQuery,
+} from '../../../__mocks__/cloudwatch-logs-test-data';
 import { ResourcesAPI } from '../../../resources/ResourcesAPI';
 import { ResourceResponse } from '../../../resources/types';
 import { LogGroup, LogGroupField } from '../../../types';
 import cloudWatchLogsLanguageDefinition, { CLOUDWATCH_LOGS_LANGUAGE_DEFINITION_ID } from '../definition';
-import { LOGS_COMMANDS, LOGS_FUNCTION_OPERATORS, SORT_DIRECTION_KEYWORDS, language } from '../language';
+import { DIFF_MODIFIERS, LOGS_COMMANDS, LOGS_FUNCTION_OPERATORS, SORT_DIRECTION_KEYWORDS, language } from '../language';
 
 import { LogsCompletionItemProvider } from './CompletionItemProvider';
 
@@ -76,6 +83,18 @@ describe('LogsCompletionItemProvider', () => {
       const suggestions = await getSuggestions(sortQuery.query, sortQuery.position);
       const suggestionLabels = suggestions.map((s) => s.label);
       expect(suggestionLabels).toEqual(expect.arrayContaining(LOGS_FUNCTION_OPERATORS));
+    });
+
+    it('returns diff modifiers after the diff keyword', async () => {
+      const suggestions = await getSuggestions(diffQuery.query, diffQuery.position);
+      const suggestionLabels = suggestions.map((s) => s.label);
+      expect(suggestionLabels).toEqual(expect.arrayContaining(DIFF_MODIFIERS));
+    });
+
+    it('returns diff modifiers when partially typed', async () => {
+      const suggestions = await getSuggestions(diffModifierQuery.query, diffModifierQuery.position);
+      const suggestionLabels = suggestions.map((s) => s.label);
+      expect(suggestionLabels).toEqual(expect.arrayContaining(DIFF_MODIFIERS));
     });
 
     it('returns `in []` snippet for the `in` keyword', async () => {

--- a/src/language/logs/completion/CompletionItemProvider.ts
+++ b/src/language/logs/completion/CompletionItemProvider.ts
@@ -8,7 +8,7 @@ import { LinkedToken } from '../../monarch/LinkedToken';
 import { TRIGGER_SUGGEST } from '../../monarch/commands';
 import { CompletionItem, CompletionItemPriority, StatementPosition, SuggestionKind } from '../../monarch/types';
 import { fetchLogGroupFields } from '../../utils';
-import { LOGS_COMMANDS, LOGS_FUNCTION_OPERATORS, SORT_DIRECTION_KEYWORDS } from '../language';
+import { LOGS_COMMANDS, LOGS_FUNCTION_OPERATORS, SORT_DIRECTION_KEYWORDS, DIFF_MODIFIERS } from '../language';
 
 import { getStatementPosition } from './statementPosition';
 import { getSuggestionKinds } from './suggestionKinds';
@@ -112,6 +112,14 @@ export class LogsCompletionItemProvider extends CompletionItemProvider {
             addSuggestion(direction, {
               sortText: CompletionItemPriority.High,
               kind: monaco.languages.CompletionItemKind.Operator,
+            });
+          });
+          break;
+        case SuggestionKind.DiffModifier:
+          DIFF_MODIFIERS.forEach((modifier) => {
+            addSuggestion(modifier, {
+              sortText: CompletionItemPriority.High,
+              kind: monaco.languages.CompletionItemKind.Keyword,
             });
           });
           break;

--- a/src/language/logs/completion/statementPosition.test.ts
+++ b/src/language/logs/completion/statementPosition.test.ts
@@ -3,6 +3,8 @@ import * as monaco from 'monaco-editor/esm/vs/editor/editor.api';
 import { monacoTypes } from '@grafana/ui';
 
 import {
+  diffQuery,
+  diffModifierQuery,
   emptyQuery,
   whitespaceOnlyQuery,
   commentOnlyQuery,
@@ -164,6 +166,24 @@ describe('getStatementPosition', () => {
     );
     expect(getStatementPosition(generateToken(multiLineFullQuery.query, { lineNumber: 5, column: 3 }))).toEqual(
       StatementPosition.Comment
+    );
+  });
+
+  it('should return StatementPosition.DiffKeyword inside the `diff` keyword', () => {
+    expect(getStatementPosition(generateToken(diffQuery.query, { lineNumber: 1, column: 22 }))).toEqual(
+      StatementPosition.DiffKeyword
+    );
+  });
+
+  it('should return StatementPosition.AfterDiffKeyword after the `diff` keyword', () => {
+    expect(getStatementPosition(generateToken(diffQuery.query, { lineNumber: 1, column: 25 }))).toEqual(
+      StatementPosition.AfterDiffKeyword
+    );
+  });
+
+  it('should return StatementPosition.DiffModifierArg when typing a diff modifier', () => {
+    expect(getStatementPosition(generateToken(diffModifierQuery.query, { lineNumber: 1, column: 28 }))).toEqual(
+      StatementPosition.DiffModifierArg
     );
   });
 });

--- a/src/language/logs/completion/statementPosition.ts
+++ b/src/language/logs/completion/statementPosition.ts
@@ -9,6 +9,7 @@ import {
   LIMIT,
   PARSE,
   DEDUP,
+  DIFF,
   LOGS_COMMANDS,
   LOGS_FUNCTION_OPERATORS,
   LOGS_LOGIC_OPERATORS,
@@ -66,6 +67,8 @@ export const getStatementPosition = (currentToken: LinkedToken | null): Statemen
     switch (normalizedCurrentToken) {
       case DEDUP:
         return StatementPosition.DedupKeyword;
+      case DIFF:
+        return StatementPosition.DiffKeyword;
       case DISPLAY:
         return StatementPosition.DisplayKeyword;
       case FIELDS:
@@ -95,6 +98,8 @@ export const getStatementPosition = (currentToken: LinkedToken | null): Statemen
     switch (normalizedPreviousNonWhiteSpace) {
       case DEDUP:
         return StatementPosition.AfterDedupKeyword;
+      case DIFF:
+        return StatementPosition.AfterDiffKeyword;
       case DISPLAY:
         return StatementPosition.AfterDisplayKeyword;
       case FIELDS:
@@ -171,6 +176,9 @@ export const getStatementPosition = (currentToken: LinkedToken | null): Statemen
       if (nearestKeyword.value === FILTER) {
         return StatementPosition.FilterArg;
       }
+      if (nearestKeyword.value === DIFF) {
+        return StatementPosition.DiffModifierArg;
+      }
       return StatementPosition.CommandArg;
     }
 
@@ -188,6 +196,9 @@ export const getStatementPosition = (currentToken: LinkedToken | null): Statemen
         }
         if (nearestKeyword.value === FILTER) {
           return StatementPosition.FilterArg;
+        }
+        if (nearestKeyword.value === DIFF) {
+          return StatementPosition.DiffModifierArg;
         }
         return StatementPosition.CommandArg;
       }

--- a/src/language/logs/completion/suggestionKinds.ts
+++ b/src/language/logs/completion/suggestionKinds.ts
@@ -7,6 +7,9 @@ export function getSuggestionKinds(statementPosition: StatementPosition): Sugges
     case StatementPosition.AfterSortKeyword:
     case StatementPosition.SortArg:
       return [SuggestionKind.SortOrderDirectionKeyword, SuggestionKind.Function];
+    case StatementPosition.AfterDiffKeyword:
+    case StatementPosition.DiffModifierArg:
+      return [SuggestionKind.DiffModifier];
     case StatementPosition.AfterDisplayKeyword:
     case StatementPosition.AfterFieldsKeyword:
     case StatementPosition.AfterFilterKeyword:

--- a/src/language/logs/language.ts
+++ b/src/language/logs/language.ts
@@ -7,6 +7,7 @@ interface CloudWatchLogsLanguage extends monacoType.languages.IMonarchLanguage {
   builtinFunctions: string[];
 }
 
+export const DIFF = 'diff';
 export const DISPLAY = 'display';
 export const FIELDS = 'fields';
 export const FILTER = 'filter';
@@ -16,7 +17,7 @@ export const SORT = 'sort';
 export const LIMIT = 'limit';
 export const PARSE = 'parse';
 export const DEDUP = 'dedup';
-export const LOGS_COMMANDS = [DISPLAY, FIELDS, FILTER, PATTERN, STATS, SORT, LIMIT, PARSE, DEDUP];
+export const LOGS_COMMANDS = [DISPLAY, FIELDS, FILTER, PATTERN, STATS, SORT, LIMIT, PARSE, DEDUP, DIFF];
 
 export const LOGS_LOGIC_OPERATORS = ['and', 'or', 'not'];
 
@@ -77,7 +78,8 @@ export const LOGS_FUNCTION_OPERATORS = [
 ];
 
 export const SORT_DIRECTION_KEYWORDS = ['asc', 'desc'];
-export const LOGS_KEYWORDS = ['like', 'by', 'in', 'as', ...SORT_DIRECTION_KEYWORDS];
+export const DIFF_MODIFIERS = ['previousDay', 'previousWeek', 'previousMonth'];
+export const LOGS_KEYWORDS = ['like', 'by', 'in', 'as', ...SORT_DIRECTION_KEYWORDS, ...DIFF_MODIFIERS];
 
 export const language: CloudWatchLogsLanguage = {
   defaultToken: 'invalid',

--- a/src/language/monarch/types.ts
+++ b/src/language/monarch/types.ts
@@ -103,6 +103,10 @@ export enum StatementPosition {
   LikeKeyword,
   AfterLikeKeyword,
 
+  DiffKeyword,
+  AfterDiffKeyword,
+  DiffModifierArg,
+
   Function,
   FunctionArg,
   CommandArg,
@@ -171,6 +175,7 @@ export enum SuggestionKind {
   Command,
   Function,
   InKeyword,
+  DiffModifier,
 
   // PPL
   BooleanFunction,


### PR DESCRIPTION
Port of https://github.com/grafana/grafana/pull/111207, depends on https://github.com/grafana/grafana-cloudwatch-datasource/pull/184 (I've set the base branch to #184)