### PR TITLE
Support log query type in annotations

### DIFF
--- a/pkg/cloudwatch/annotation_query.go
+++ b/pkg/cloudwatch/annotation_query.go
@@ -10,8 +10,11 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
 	cloudwatchtypes "github.com/aws/aws-sdk-go-v2/service/cloudwatch/types"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
+	cloudwatchlogstypes "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
 
 	"github.com/grafana/grafana-cloudwatch-datasource/pkg/cloudwatch/kinds/dataquery"
+	"github.com/grafana/grafana-cloudwatch-datasource/pkg/cloudwatch/models"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/grafana/grafana-plugin-sdk-go/data"
 )
@@ -25,6 +28,13 @@ type annotationEvent struct {
 
 func (ds *DataSource) executeAnnotationQuery(ctx context.Context, model DataQueryJson, query backend.DataQuery) (*backend.QueryDataResponse, error) {
 	result := backend.NewQueryDataResponse()
+
+	// Route to logs annotation handler if annotation type is logs
+	if model.AnnotationType != nil && *model.AnnotationType == dataquery.CloudWatchAnnotationTypeLogs {
+		return ds.executeLogsAnnotationQuery(ctx, model, query)
+	}
+
+	// Default to metrics annotation (CloudWatch Alarms) for backward compatibility
 	statistic := ""
 
 	if model.Statistic != nil {
@@ -203,4 +213,117 @@ func filterAlarms(alarms *cloudwatch.DescribeAlarmsOutput, namespace string, met
 	}
 
 	return alarmNames
+}
+
+func (ds *DataSource) executeLogsAnnotationQuery(ctx context.Context, model DataQueryJson, query backend.DataQuery) (*backend.QueryDataResponse, error) {
+	result := backend.NewQueryDataResponse()
+
+	// Validate logs annotation query
+	if model.Expression == nil || *model.Expression == "" {
+		result.Responses[query.RefID] = backend.ErrorResponseWithErrorSource(backend.DownstreamError(errors.New("expression is required for logs annotations")))
+		return result, nil
+	}
+
+	if (model.LogGroups == nil || len(model.LogGroups) == 0) && (model.LogGroupNames == nil || len(model.LogGroupNames) == 0) {
+		result.Responses[query.RefID] = backend.ErrorResponseWithErrorSource(backend.DownstreamError(errors.New("log groups are required for logs annotations")))
+		return result, nil
+	}
+
+	region := model.Region
+	if region == "" || region == defaultRegion {
+		region = ds.Settings.Region
+	}
+
+	logsClient, err := ds.getCWLogsClient(ctx, region)
+	if err != nil {
+		result.Responses[query.RefID] = backend.ErrorResponseWithErrorSource(fmt.Errorf("%v: %w", "failed to get logs client", err))
+		return result, nil
+	}
+
+	// Create logs query from annotation query
+	logsQuery := models.LogsQuery{
+		CloudWatchLogsQuery: dataquery.CloudWatchLogsQuery{
+			Region:        region,
+			Expression:    model.Expression,
+			LogGroups:     model.LogGroups,
+			LogGroupNames: model.LogGroupNames,
+			QueryLanguage: model.QueryLanguage,
+		},
+		QueryString: *model.Expression,
+	}
+
+	// Execute the logs query synchronously
+	getQueryResultsOutput, err := ds.syncQuery(ctx, logsClient, query, logsQuery, ds.Settings.LogsTimeout.Duration)
+	if err != nil {
+		result.Responses[query.RefID] = backend.ErrorResponseWithErrorSource(backend.DownstreamError(fmt.Errorf("%v: %w", "failed to execute logs query", err)))
+		return result, nil
+	}
+
+	// Transform logs results to annotations
+	annotations, err := logsResultsToAnnotations(getQueryResultsOutput)
+	if err != nil {
+		result.Responses[query.RefID] = backend.ErrorResponseWithErrorSource(fmt.Errorf("%v: %w", "failed to transform logs results", err))
+		return result, nil
+	}
+
+	respD := result.Responses[query.RefID]
+	respD.Frames = append(respD.Frames, transformAnnotationToTable(annotations, query))
+	result.Responses[query.RefID] = respD
+
+	return result, nil
+}
+
+func logsResultsToAnnotations(results *cloudwatchlogs.GetQueryResultsOutput) ([]*annotationEvent, error) {
+	annotations := make([]*annotationEvent, 0)
+
+	for _, row := range results.Results {
+		var timestamp time.Time
+		var message string
+		title := "Log Event"
+		tags := ""
+
+		// Extract fields from the log result
+		for _, field := range row {
+			if field.Field == nil || field.Value == nil {
+				continue
+			}
+
+			switch *field.Field {
+			case "@timestamp":
+				// Parse timestamp
+				t, err := time.Parse(time.RFC3339, *field.Value)
+				if err != nil {
+					// Try parsing as Unix timestamp in milliseconds
+					var ms int64
+					_, err := fmt.Sscanf(*field.Value, "%d", &ms)
+					if err == nil {
+						timestamp = time.Unix(0, ms*int64(time.Millisecond))
+					}
+				} else {
+					timestamp = t
+				}
+			case "@message":
+				message = *field.Value
+			case "@logStream":
+				tags = *field.Value
+			default:
+				// Use the first non-standard field as title if available
+				if title == "Log Event" && *field.Field != "@ptr" && *field.Field != "@log" {
+					title = fmt.Sprintf("%s: %s", *field.Field, *field.Value)
+				}
+			}
+		}
+
+		// Only create annotation if we have a timestamp
+		if !timestamp.IsZero() {
+			annotations = append(annotations, &annotationEvent{
+				Time:  timestamp,
+				Title: title,
+				Tags:  tags,
+				Text:  message,
+			})
+		}
+	}
+
+	return annotations, nil
 }

--- a/pkg/cloudwatch/annotation_query_test.go
+++ b/pkg/cloudwatch/annotation_query_test.go
@@ -4,10 +4,14 @@ import (
 	"context"
 	"encoding/json"
 	"testing"
+	"time"
 
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/cloudwatch"
+	"github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs"
+	cloudwatchlogstypes "github.com/aws/aws-sdk-go-v2/service/cloudwatchlogs/types"
 
+	"github.com/grafana/grafana-cloudwatch-datasource/pkg/cloudwatch/kinds/dataquery"
 	"github.com/grafana/grafana-cloudwatch-datasource/pkg/cloudwatch/models"
 	"github.com/grafana/grafana-plugin-sdk-go/backend"
 	"github.com/stretchr/testify/assert"
@@ -86,5 +90,320 @@ func TestQuery_AnnotationQuery(t *testing.T) {
 			ActionPrefix:    aws.String("some_action_prefix"),
 			AlarmNamePrefix: aws.String("some_alarm_name_prefix"),
 		}, client.calls.describeAlarms[0])
+	})
+
+	t.Run("Routes to metrics handler when annotationType is not specified (backward compatibility)", func(t *testing.T) {
+		client = fakeCWAnnotationsClient{describeAlarmsForMetricOutput: &cloudwatch.DescribeAlarmsForMetricOutput{}}
+
+		_, err := ds.QueryData(context.Background(), &backend.QueryDataRequest{
+			PluginContext: backend.PluginContext{
+				DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{},
+			},
+			Queries: []backend.DataQuery{
+				{
+					JSON: json.RawMessage(`{
+						"type":    "annotationQuery",
+						"region":    "us-east-1",
+						"namespace": "custom",
+						"metricName": "CPUUtilization",
+						"statistic": "Average"
+					}`),
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		// Should call metrics annotation handler
+		require.Len(t, client.calls.describeAlarmsForMetric, 1)
+	})
+
+	t.Run("Routes to metrics handler when annotationType is 'metrics'", func(t *testing.T) {
+		client = fakeCWAnnotationsClient{describeAlarmsForMetricOutput: &cloudwatch.DescribeAlarmsForMetricOutput{}}
+
+		_, err := ds.QueryData(context.Background(), &backend.QueryDataRequest{
+			PluginContext: backend.PluginContext{
+				DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{},
+			},
+			Queries: []backend.DataQuery{
+				{
+					JSON: json.RawMessage(`{
+						"type":    "annotationQuery",
+						"annotationType": "metrics",
+						"region":    "us-east-1",
+						"namespace": "custom",
+						"metricName": "CPUUtilization",
+						"statistic": "Average"
+					}`),
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		// Should call metrics annotation handler
+		require.Len(t, client.calls.describeAlarmsForMetric, 1)
+	})
+}
+
+func TestQuery_LogsAnnotationQuery(t *testing.T) {
+	ds := newTestDatasource()
+	origNewCWLogsClient := NewCWLogsClient
+	t.Cleanup(func() {
+		NewCWLogsClient = origNewCWLogsClient
+	})
+
+	timestamp := time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)
+	var logsClient fakeCWLogsClient
+	NewCWLogsClient = func(aws.Config) models.CWLogsClient {
+		return &logsClient
+	}
+
+	t.Run("Returns error when expression is missing", func(t *testing.T) {
+		resp, err := ds.QueryData(context.Background(), &backend.QueryDataRequest{
+			PluginContext: backend.PluginContext{
+				DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{},
+			},
+			Queries: []backend.DataQuery{
+				{
+					RefID: "A",
+					JSON: json.RawMessage(`{
+						"type": "annotationQuery",
+						"annotationType": "logs",
+						"region": "us-east-1",
+						"logGroups": [{"arn": "arn:aws:logs:us-east-1:123456789012:log-group:/aws/lambda/test", "name": "/aws/lambda/test"}]
+					}`),
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		// Should return error in response
+		require.Contains(t, resp.Responses, "A")
+		assert.Error(t, resp.Responses["A"].Error)
+		assert.Contains(t, resp.Responses["A"].Error.Error(), "expression is required")
+	})
+
+	t.Run("Returns error when log groups are missing", func(t *testing.T) {
+		resp, err := ds.QueryData(context.Background(), &backend.QueryDataRequest{
+			PluginContext: backend.PluginContext{
+				DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{},
+			},
+			Queries: []backend.DataQuery{
+				{
+					RefID: "A",
+					JSON: json.RawMessage(`{
+						"type": "annotationQuery",
+						"annotationType": "logs",
+						"region": "us-east-1",
+						"expression": "fields @timestamp, @message | sort @timestamp desc"
+					}`),
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		// Should return error in response
+		require.Contains(t, resp.Responses, "A")
+		assert.Error(t, resp.Responses["A"].Error)
+		assert.Contains(t, resp.Responses["A"].Error.Error(), "log groups are required")
+	})
+
+	t.Run("Executes logs annotation query successfully", func(t *testing.T) {
+		logsClient = fakeCWLogsClient{
+			queryResults: cloudwatchlogs.GetQueryResultsOutput{
+				Status: cloudwatchlogstypes.QueryStatusComplete,
+				Results: [][]cloudwatchlogstypes.ResultField{
+					{
+						{Field: aws.String("@timestamp"), Value: aws.String(timestamp.Format(time.RFC3339))},
+						{Field: aws.String("@message"), Value: aws.String("Test log message")},
+						{Field: aws.String("@logStream"), Value: aws.String("test-stream")},
+					},
+				},
+			},
+		}
+
+		resp, err := ds.QueryData(context.Background(), &backend.QueryDataRequest{
+			PluginContext: backend.PluginContext{
+				DataSourceInstanceSettings: &backend.DataSourceInstanceSettings{},
+			},
+			Queries: []backend.DataQuery{
+				{
+					RefID: "A",
+					JSON: json.RawMessage(`{
+						"type": "annotationQuery",
+						"annotationType": "logs",
+						"region": "us-east-1",
+						"expression": "fields @timestamp, @message | sort @timestamp desc",
+						"logGroups": [{"arn": "arn:aws:logs:us-east-1:123456789012:log-group:/aws/lambda/test", "name": "/aws/lambda/test"}]
+					}`),
+					TimeRange: backend.TimeRange{
+						From: timestamp.Add(-1 * time.Hour),
+						To:   timestamp.Add(1 * time.Hour),
+					},
+				},
+			},
+		})
+		require.NoError(t, err)
+
+		// Should return annotation frame
+		require.Contains(t, resp.Responses, "A")
+		assert.NoError(t, resp.Responses["A"].Error)
+		require.Len(t, resp.Responses["A"].Frames, 1)
+
+		frame := resp.Responses["A"].Frames[0]
+		assert.Equal(t, "A", frame.Name)
+		require.Len(t, frame.Fields, 4) // time, title, tags, text
+		assert.Equal(t, "time", frame.Fields[0].Name)
+		assert.Equal(t, "title", frame.Fields[1].Name)
+		assert.Equal(t, "tags", frame.Fields[2].Name)
+		assert.Equal(t, "text", frame.Fields[3].Name)
+	})
+}
+
+func TestLogsResultsToAnnotations(t *testing.T) {
+	t.Run("Parses RFC3339 timestamp correctly", func(t *testing.T) {
+		timestamp := time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)
+		results := &cloudwatchlogs.GetQueryResultsOutput{
+			Status: cloudwatchlogstypes.QueryStatusComplete,
+			Results: [][]cloudwatchlogstypes.ResultField{
+				{
+					{Field: aws.String("@timestamp"), Value: aws.String(timestamp.Format(time.RFC3339))},
+					{Field: aws.String("@message"), Value: aws.String("Test message")},
+				},
+			},
+		}
+
+		annotations, err := logsResultsToAnnotations(results)
+		require.NoError(t, err)
+		require.Len(t, annotations, 1)
+
+		assert.Equal(t, timestamp, annotations[0].Time)
+		assert.Equal(t, "Test message", annotations[0].Text)
+	})
+
+	t.Run("Parses Unix millisecond timestamp correctly", func(t *testing.T) {
+		timestamp := time.Date(2023, 1, 1, 12, 0, 0, 0, time.UTC)
+		timestampMs := timestamp.UnixNano() / int64(time.Millisecond)
+
+		results := &cloudwatchlogs.GetQueryResultsOutput{
+			Status: cloudwatchlogstypes.QueryStatusComplete,
+			Results: [][]cloudwatchlogstypes.ResultField{
+				{
+					{Field: aws.String("@timestamp"), Value: aws.String("1672574400000")}, // Unix ms
+					{Field: aws.String("@message"), Value: aws.String("Test message")},
+				},
+			},
+		}
+
+		annotations, err := logsResultsToAnnotations(results)
+		require.NoError(t, err)
+		require.Len(t, annotations, 1)
+
+		// Allow for small time differences due to conversion
+		assert.WithinDuration(t, time.Unix(0, timestampMs*int64(time.Millisecond)), annotations[0].Time, time.Second)
+	})
+
+	t.Run("Extracts @message field", func(t *testing.T) {
+		results := &cloudwatchlogs.GetQueryResultsOutput{
+			Status: cloudwatchlogstypes.QueryStatusComplete,
+			Results: [][]cloudwatchlogstypes.ResultField{
+				{
+					{Field: aws.String("@timestamp"), Value: aws.String(time.Now().Format(time.RFC3339))},
+					{Field: aws.String("@message"), Value: aws.String("This is my log message")},
+				},
+			},
+		}
+
+		annotations, err := logsResultsToAnnotations(results)
+		require.NoError(t, err)
+		require.Len(t, annotations, 1)
+
+		assert.Equal(t, "This is my log message", annotations[0].Text)
+	})
+
+	t.Run("Uses @logStream as tags", func(t *testing.T) {
+		results := &cloudwatchlogs.GetQueryResultsOutput{
+			Status: cloudwatchlogstypes.QueryStatusComplete,
+			Results: [][]cloudwatchlogstypes.ResultField{
+				{
+					{Field: aws.String("@timestamp"), Value: aws.String(time.Now().Format(time.RFC3339))},
+					{Field: aws.String("@message"), Value: aws.String("Test message")},
+					{Field: aws.String("@logStream"), Value: aws.String("my-log-stream")},
+				},
+			},
+		}
+
+		annotations, err := logsResultsToAnnotations(results)
+		require.NoError(t, err)
+		require.Len(t, annotations, 1)
+
+		assert.Equal(t, "my-log-stream", annotations[0].Tags)
+	})
+
+	t.Run("Uses custom field as title", func(t *testing.T) {
+		results := &cloudwatchlogs.GetQueryResultsOutput{
+			Status: cloudwatchlogstypes.QueryStatusComplete,
+			Results: [][]cloudwatchlogstypes.ResultField{
+				{
+					{Field: aws.String("@timestamp"), Value: aws.String(time.Now().Format(time.RFC3339))},
+					{Field: aws.String("@message"), Value: aws.String("Test message")},
+					{Field: aws.String("severity"), Value: aws.String("ERROR")},
+				},
+			},
+		}
+
+		annotations, err := logsResultsToAnnotations(results)
+		require.NoError(t, err)
+		require.Len(t, annotations, 1)
+
+		assert.Equal(t, "severity: ERROR", annotations[0].Title)
+	})
+
+	t.Run("Skips rows without timestamp", func(t *testing.T) {
+		results := &cloudwatchlogs.GetQueryResultsOutput{
+			Status: cloudwatchlogstypes.QueryStatusComplete,
+			Results: [][]cloudwatchlogstypes.ResultField{
+				{
+					{Field: aws.String("@message"), Value: aws.String("Message without timestamp")},
+				},
+				{
+					{Field: aws.String("@timestamp"), Value: aws.String(time.Now().Format(time.RFC3339))},
+					{Field: aws.String("@message"), Value: aws.String("Message with timestamp")},
+				},
+			},
+		}
+
+		annotations, err := logsResultsToAnnotations(results)
+		require.NoError(t, err)
+		require.Len(t, annotations, 1)
+
+		assert.Equal(t, "Message with timestamp", annotations[0].Text)
+	})
+
+	t.Run("Handles nil fields gracefully", func(t *testing.T) {
+		results := &cloudwatchlogs.GetQueryResultsOutput{
+			Status: cloudwatchlogstypes.QueryStatusComplete,
+			Results: [][]cloudwatchlogstypes.ResultField{
+				{
+					{Field: aws.String("@timestamp"), Value: aws.String(time.Now().Format(time.RFC3339))},
+					{Field: nil, Value: aws.String("Should be ignored")},
+					{Field: aws.String("@message"), Value: nil},
+				},
+			},
+		}
+
+		annotations, err := logsResultsToAnnotations(results)
+		require.NoError(t, err)
+		require.Len(t, annotations, 1)
+	})
+
+	t.Run("Returns empty array for empty results", func(t *testing.T) {
+		results := &cloudwatchlogs.GetQueryResultsOutput{
+			Status:  cloudwatchlogstypes.QueryStatusComplete,
+			Results: [][]cloudwatchlogstypes.ResultField{},
+		}
+
+		annotations, err := logsResultsToAnnotations(results)
+		require.NoError(t, err)
+		assert.Len(t, annotations, 0)
 	})
 }

--- a/pkg/cloudwatch/kinds/dataquery/types_dataquery.go
+++ b/pkg/cloudwatch/kinds/dataquery/types_dataquery.go
@@ -379,20 +379,21 @@ func NewCloudWatchLogsAnomaliesQuery() *CloudWatchLogsAnomaliesQuery {
 	return &CloudWatchLogsAnomaliesQuery{}
 }
 
+type CloudWatchAnnotationType string
+
+const (
+	CloudWatchAnnotationTypeMetrics CloudWatchAnnotationType = "metrics"
+	CloudWatchAnnotationTypeLogs    CloudWatchAnnotationType = "logs"
+)
+
 // Shape of a CloudWatch Annotation query
 // TS type is CloudWatchDefaultQuery = Omit<CloudWatchLogsQuery, 'queryMode'> & CloudWatchMetricsQuery, declared in veneer
 // #CloudWatchDefaultQuery: #CloudWatchLogsQuery & #CloudWatchMetricsQuery @cuetsy(kind="type")
 type CloudWatchAnnotationQuery struct {
 	// Whether a query is a Metrics, Logs, or Annotations query
 	QueryMode CloudWatchQueryMode `json:"queryMode"`
-	// Enable matching on the prefix of the action name or alarm name, specify the prefixes with actionPrefix and/or alarmNamePrefix
-	PrefixMatching *bool `json:"prefixMatching,omitempty"`
-	// Use this parameter to filter the results of the operation to only those alarms
-	// that use a certain alarm action. For example, you could specify the ARN of
-	// an SNS topic to find all alarms that send notifications to that topic.
-	// e.g. `arn:aws:sns:us-east-1:123456789012:my-app-` would match `arn:aws:sns:us-east-1:123456789012:my-app-action`
-	// but not match `arn:aws:sns:us-east-1:123456789012:your-app-action`
-	ActionPrefix *string `json:"actionPrefix,omitempty"`
+	// The type of annotation query - metrics (alarms) or logs (log events)
+	AnnotationType *CloudWatchAnnotationType `json:"annotationType,omitempty"`
 	// A unique identifier for the query within the list of targets.
 	// In server side expressions, the refId is used as a variable name to identify results.
 	// By default, the UI will assign A->Z; however setting meaningful names may be useful.
@@ -402,33 +403,55 @@ type CloudWatchAnnotationQuery struct {
 	// Specify the query flavor
 	// TODO make this required and give it a default
 	QueryType *string `json:"queryType,omitempty"`
-	// AWS region to query for the metric
+	// AWS region to query for the annotations
 	Region string `json:"region"`
+	// For mixed data sources the selected datasource is on the query level.
+	// For non mixed scenarios this is undefined.
+	// TODO find a better way to do this ^ that's friendly to schema
+	// TODO this shouldn't be unknown but DataSourceRef | null
+	Datasource any `json:"datasource,omitempty"`
+
+	// ===== Metrics Annotation Fields (CloudWatch Alarms) =====
+	// The ID of the AWS account to query for the metric, specifying `all` will query all accounts that the monitoring account is permitted to query.
+	AccountId *string `json:"accountId,omitempty"`
 	// A namespace is a container for CloudWatch metrics. Metrics in different namespaces are isolated from each other, so that metrics from different applications are not mistakenly aggregated into the same statistics. For example, Amazon EC2 uses the AWS/EC2 namespace.
-	Namespace string `json:"namespace"`
+	Namespace *string `json:"namespace,omitempty"`
 	// Name of the metric
 	MetricName *string `json:"metricName,omitempty"`
 	// The dimensions of the metric
 	Dimensions *Dimensions `json:"dimensions,omitempty"`
 	// Only show metrics that exactly match all defined dimension names.
 	MatchExact *bool `json:"matchExact,omitempty"`
-	// The length of time associated with a specific Amazon CloudWatch statistic. Can be specified by a number of seconds, 'auto', or as a duration string e.g. '15m' being 15 minutes
-	Period *string `json:"period,omitempty"`
-	// The ID of the AWS account to query for the metric, specifying `all` will query all accounts that the monitoring account is permitted to query.
-	AccountId *string `json:"accountId,omitempty"`
 	// Metric data aggregations over specified periods of time. For detailed definitions of the statistics supported by CloudWatch, see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Statistics-definitions.html.
 	Statistic *string `json:"statistic,omitempty"`
+	// The length of time associated with a specific Amazon CloudWatch statistic. Can be specified by a number of seconds, 'auto', or as a duration string e.g. '15m' being 15 minutes
+	Period *string `json:"period,omitempty"`
+	// Use this parameter to filter the results of the operation to only those alarms
+	// that use a certain alarm action. For example, you could specify the ARN of
+	// an SNS topic to find all alarms that send notifications to that topic.
+	// e.g. `arn:aws:sns:us-east-1:123456789012:my-app-` would match `arn:aws:sns:us-east-1:123456789012:my-app-action`
+	// but not match `arn:aws:sns:us-east-1:123456789012:your-app-action`
+	ActionPrefix *string `json:"actionPrefix,omitempty"`
 	// An alarm name prefix. If you specify this parameter, you receive information
 	// about all alarms that have names that start with this prefix.
 	// e.g. `my-team-service-` would match `my-team-service-high-cpu` but not match `your-team-service-high-cpu`
 	AlarmNamePrefix *string `json:"alarmNamePrefix,omitempty"`
-	// For mixed data sources the selected datasource is on the query level.
-	// For non mixed scenarios this is undefined.
-	// TODO find a better way to do this ^ that's friendly to schema
-	// TODO this shouldn't be unknown but DataSourceRef | null
-	Datasource any `json:"datasource,omitempty"`
+	// Enable matching on the prefix of the action name or alarm name, specify the prefixes with actionPrefix and/or alarmNamePrefix
+	PrefixMatching *bool `json:"prefixMatching,omitempty"`
 	// @deprecated use statistic
 	Statistics []string `json:"statistics,omitempty"`
+
+	// ===== Logs Annotation Fields (CloudWatch Logs Insights) =====
+	// The CloudWatch Logs Insights query to execute
+	Expression *string `json:"expression,omitempty"`
+	// Log groups to query
+	LogGroups []LogGroup `json:"logGroups,omitempty"`
+	// @deprecated use logGroups
+	LogGroupNames []string `json:"logGroupNames,omitempty"`
+	// Language used for querying logs, can be CWLI, SQL, or PPL. If empty, the default language is CWLI.
+	QueryLanguage *LogsQueryLanguage `json:"queryLanguage,omitempty"`
+	// Whether a query is a Logs Insights or Log Anomalies query
+	LogsMode *LogsMode `json:"logsMode,omitempty"`
 }
 
 // NewCloudWatchAnnotationQuery creates a new CloudWatchAnnotationQuery object.

--- a/src/annotationSupport.test.ts
+++ b/src/annotationSupport.test.ts
@@ -163,5 +163,145 @@ describe('annotationSupport', () => {
         expect(CloudWatchAnnotationSupport.prepareQuery(query)).toBeUndefined();
       });
     });
+
+    describe('Logs Annotation Validation', () => {
+      const validLogsAnnotationQuery: CloudWatchAnnotationQuery = {
+        queryMode: 'Annotations',
+        annotationType: 'logs',
+        region: 'us-east-1',
+        refId: 'anno',
+        expression: 'fields @timestamp, @message | sort @timestamp desc',
+        logGroups: [
+          {
+            arn: 'arn:aws:logs:us-east-1:123456789012:log-group:/aws/lambda/test',
+            name: '/aws/lambda/test',
+          },
+        ],
+      };
+
+      describe('is being called with a complete logs annotation query', () => {
+        it('should return the annotation target', () => {
+          const query = {
+            ...annotationQuery,
+            target: validLogsAnnotationQuery,
+          };
+          expect(CloudWatchAnnotationSupport.prepareQuery(query)).toEqual(validLogsAnnotationQuery);
+        });
+      });
+
+      describe('is being called with logs annotation query missing expression', () => {
+        it('should return undefined', () => {
+          const query = {
+            ...annotationQuery,
+            target: {
+              ...validLogsAnnotationQuery,
+              expression: undefined,
+            },
+          };
+          expect(CloudWatchAnnotationSupport.prepareQuery(query)).toBeUndefined();
+        });
+
+        it('should return undefined when expression is empty string', () => {
+          const query = {
+            ...annotationQuery,
+            target: {
+              ...validLogsAnnotationQuery,
+              expression: '',
+            },
+          };
+          expect(CloudWatchAnnotationSupport.prepareQuery(query)).toBeUndefined();
+        });
+      });
+
+      describe('is being called with logs annotation query missing log groups', () => {
+        it('should return undefined when logGroups is empty', () => {
+          const query = {
+            ...annotationQuery,
+            target: {
+              ...validLogsAnnotationQuery,
+              logGroups: [],
+              logGroupNames: undefined,
+            },
+          };
+          expect(CloudWatchAnnotationSupport.prepareQuery(query)).toBeUndefined();
+        });
+
+        it('should return undefined when logGroups is undefined', () => {
+          const query = {
+            ...annotationQuery,
+            target: {
+              ...validLogsAnnotationQuery,
+              logGroups: undefined,
+              logGroupNames: undefined,
+            },
+          };
+          expect(CloudWatchAnnotationSupport.prepareQuery(query)).toBeUndefined();
+        });
+      });
+
+      describe('is being called with logs annotation query using legacy logGroupNames', () => {
+        it('should return the annotation target when logGroupNames is provided', () => {
+          const query = {
+            ...annotationQuery,
+            target: {
+              ...validLogsAnnotationQuery,
+              logGroups: undefined,
+              logGroupNames: ['/aws/lambda/test'],
+            },
+          };
+          expect(CloudWatchAnnotationSupport.prepareQuery(query)).toEqual(query.target);
+        });
+
+        it('should return undefined when logGroupNames is empty', () => {
+          const query = {
+            ...annotationQuery,
+            target: {
+              ...validLogsAnnotationQuery,
+              logGroups: undefined,
+              logGroupNames: [],
+            },
+          };
+          expect(CloudWatchAnnotationSupport.prepareQuery(query)).toBeUndefined();
+        });
+      });
+
+      describe('is being called with logs annotation query with both logGroups and logGroupNames', () => {
+        it('should return the annotation target (logGroups takes precedence)', () => {
+          const query = {
+            ...annotationQuery,
+            target: {
+              ...validLogsAnnotationQuery,
+              logGroups: [
+                {
+                  arn: 'arn:aws:logs:us-east-1:123456789012:log-group:/aws/lambda/test',
+                  name: '/aws/lambda/test',
+                },
+              ],
+              logGroupNames: ['/aws/lambda/legacy'],
+            },
+          };
+          expect(CloudWatchAnnotationSupport.prepareQuery(query)).toEqual(query.target);
+        });
+      });
+    });
+
+    describe('Backward Compatibility', () => {
+      describe('is being called with metrics annotation without annotationType field', () => {
+        it('should return the annotation target (defaults to metrics)', () => {
+          const queryWithoutType = {
+            ...annotationQuery,
+            target: {
+              queryMode: 'Annotations' as const,
+              region: 'us-east-2',
+              namespace: 'AWS/EC2',
+              metricName: 'CPUUtilization',
+              statistic: 'Average',
+              refId: 'anno',
+            },
+          };
+          expect(CloudWatchAnnotationSupport.prepareQuery(queryWithoutType)).toEqual(queryWithoutType.target);
+        });
+      });
+    });
   });
 });

--- a/src/annotationSupport.ts
+++ b/src/annotationSupport.ts
@@ -2,7 +2,7 @@ import { AnnotationQuery } from '@grafana/data';
 
 import { AnnotationQueryEditor } from './components/AnnotationQueryEditor/AnnotationQueryEditor';
 import { DEFAULT_ANNOTATIONS_QUERY } from './defaultQueries';
-import { isCloudWatchAnnotation } from './guards';
+import { isCloudWatchAnnotation, isLogsAnnotationQuery, isMetricsAnnotationQuery } from './guards';
 import { CloudWatchAnnotationQuery, CloudWatchQuery, LegacyAnnotationQuery } from './types';
 
 export const CloudWatchAnnotationSupport = {
@@ -38,12 +38,28 @@ export const CloudWatchAnnotationSupport = {
       return undefined;
     }
 
-    const { prefixMatching, actionPrefix, alarmNamePrefix, statistic, namespace, metricName } = anno.target;
-    const validPrefixMatchingQuery = !!prefixMatching && !!actionPrefix && !!alarmNamePrefix;
-    const validMetricStatQuery = !prefixMatching && !!namespace && !!metricName && !!statistic;
+    // Check if it's a logs annotation query
+    if (isLogsAnnotationQuery(anno.target)) {
+      const { expression, logGroups, logGroupNames } = anno.target;
+      const hasLogGroups = (logGroups && logGroups.length > 0) || (logGroupNames && logGroupNames.length > 0);
+      const validLogsQuery = !!expression && hasLogGroups;
 
-    if (validPrefixMatchingQuery || validMetricStatQuery) {
-      return anno.target;
+      if (validLogsQuery) {
+        return anno.target;
+      }
+
+      return undefined;
+    }
+
+    // Check if it's a metrics annotation query (default)
+    if (isMetricsAnnotationQuery(anno.target)) {
+      const { prefixMatching, actionPrefix, alarmNamePrefix, statistic, namespace, metricName } = anno.target;
+      const validPrefixMatchingQuery = !!prefixMatching && !!actionPrefix && !!alarmNamePrefix;
+      const validMetricStatQuery = !prefixMatching && !!namespace && !!metricName && !!statistic;
+
+      if (validPrefixMatchingQuery || validMetricStatQuery) {
+        return anno.target;
+      }
     }
 
     return undefined;

--- a/src/components/AnnotationQueryEditor/AnnotationQueryEditor.test.tsx
+++ b/src/components/AnnotationQueryEditor/AnnotationQueryEditor.test.tsx
@@ -82,4 +82,140 @@ describe('AnnotationQueryEditor', () => {
     await waitFor(() => render(<AnnotationQueryEditor {...props} />));
     expect(await screen.queryByText('Account')).toBeNull();
   });
+
+  describe('Annotation Type Selector', () => {
+    it('should render annotation type selector with both options', async () => {
+      render(<AnnotationQueryEditor {...props} />);
+      await waitFor(() => {
+        expect(screen.getByText('Annotation type')).toBeInTheDocument();
+      });
+    });
+
+    it('should default to metrics annotation type', async () => {
+      const metricsQuery: CloudWatchAnnotationQuery = {
+        ...q,
+        queryMode: 'Annotations',
+      };
+      render(<AnnotationQueryEditor {...props} query={metricsQuery} />);
+      await waitFor(() => {
+        // MetricStatEditor should be visible for metrics
+        expect(screen.getByText('Namespace')).toBeInTheDocument();
+      });
+    });
+
+    it('should display metrics editor components when annotationType is metrics', async () => {
+      const metricsQuery: CloudWatchAnnotationQuery = {
+        ...q,
+        queryMode: 'Annotations',
+        annotationType: 'metrics',
+      };
+      render(<AnnotationQueryEditor {...props} query={metricsQuery} />);
+      await waitFor(() => {
+        expect(screen.getByText('Namespace')).toBeInTheDocument();
+        expect(screen.getByText('Metric name')).toBeInTheDocument();
+        expect(screen.getByText('Period')).toBeInTheDocument();
+        expect(screen.getByText('Enable Prefix Matching')).toBeInTheDocument();
+      });
+    });
+
+    it('should display logs editor components when annotationType is logs', async () => {
+      const logsQuery: CloudWatchAnnotationQuery = {
+        refId: 'A',
+        queryMode: 'Annotations',
+        annotationType: 'logs',
+        region: 'us-east-1',
+        expression: 'fields @timestamp, @message',
+        logGroups: [],
+      };
+
+      ds.datasource.resources.getLogGroups = jest.fn().mockResolvedValue([]);
+
+      render(<AnnotationQueryEditor {...props} query={logsQuery} />);
+      await waitFor(() => {
+        expect(screen.getByText('Log groups')).toBeInTheDocument();
+      });
+    });
+
+    it('should hide metrics-specific fields when annotationType is logs', async () => {
+      const logsQuery: CloudWatchAnnotationQuery = {
+        refId: 'A',
+        queryMode: 'Annotations',
+        annotationType: 'logs',
+        region: 'us-east-1',
+        expression: 'fields @timestamp, @message',
+        logGroups: [],
+      };
+
+      ds.datasource.resources.getLogGroups = jest.fn().mockResolvedValue([]);
+
+      render(<AnnotationQueryEditor {...props} query={logsQuery} />);
+      await waitFor(() => {
+        expect(screen.queryByText('Namespace')).toBeNull();
+        expect(screen.queryByText('Metric name')).toBeNull();
+        expect(screen.queryByText('Period')).toBeNull();
+        expect(screen.queryByText('Enable Prefix Matching')).toBeNull();
+      });
+    });
+
+    it('should show region selector for both annotation types', async () => {
+      const metricsQuery: CloudWatchAnnotationQuery = {
+        ...q,
+        queryMode: 'Annotations',
+        annotationType: 'metrics',
+      };
+      render(<AnnotationQueryEditor {...props} query={metricsQuery} />);
+      await waitFor(() => {
+        expect(screen.getByText('Region')).toBeInTheDocument();
+      });
+
+      const logsQuery: CloudWatchAnnotationQuery = {
+        refId: 'A',
+        queryMode: 'Annotations',
+        annotationType: 'logs',
+        region: 'us-east-1',
+        expression: 'fields @timestamp, @message',
+        logGroups: [],
+      };
+
+      ds.datasource.resources.getLogGroups = jest.fn().mockResolvedValue([]);
+
+      render(<AnnotationQueryEditor {...props} query={logsQuery} />);
+      await waitFor(() => {
+        expect(screen.getByText('Region')).toBeInTheDocument();
+      });
+    });
+  });
+
+  describe('Annotation Type Switching', () => {
+    it('should initialize logs mode with default expression', () => {
+      const onChange = jest.fn();
+      const metricsQuery: CloudWatchAnnotationQuery = {
+        ...q,
+        queryMode: 'Annotations',
+        annotationType: 'metrics',
+      };
+
+      render(<AnnotationQueryEditor {...props} query={metricsQuery} onChange={onChange} />);
+
+      // When user clicks to switch to logs, onChange should be called with logs fields
+      // Note: This requires user interaction simulation which is complex in this test
+      // The actual logic is tested through the component behavior
+    });
+
+    it('should preserve region when switching annotation types', async () => {
+      const metricsQuery: CloudWatchAnnotationQuery = {
+        ...q,
+        queryMode: 'Annotations',
+        annotationType: 'metrics',
+        region: 'eu-west-1',
+      };
+
+      render(<AnnotationQueryEditor {...props} query={metricsQuery} />);
+      await waitFor(() => {
+        // Region should be displayed
+        const regionInputs = screen.getAllByDisplayValue('eu-west-1');
+        expect(regionInputs.length).toBeGreaterThan(0);
+      });
+    });
+  });
 });

--- a/src/components/AnnotationQueryEditor/AnnotationQueryEditor.tsx
+++ b/src/components/AnnotationQueryEditor/AnnotationQueryEditor.tsx
@@ -1,16 +1,24 @@
 import { ChangeEvent } from 'react';
 
-import { QueryEditorProps } from '@grafana/data';
+import { QueryEditorProps, SelectableValue } from '@grafana/data';
 import { EditorField, EditorHeader, EditorRow, EditorSwitch, InlineSelect } from '@grafana/plugin-ui';
 import { Alert, Input, Space } from '@grafana/ui';
 
 import { CloudWatchDatasource } from '../../datasource';
-import { isCloudWatchAnnotationQuery } from '../../guards';
+import { DEFAULT_CWLI_QUERY_STRING } from '../../defaultQueries';
+import { isCloudWatchAnnotationQuery, isLogsAnnotationQuery } from '../../guards';
 import { useRegions } from '../../hooks';
-import { CloudWatchJsonData, CloudWatchQuery, MetricStat } from '../../types';
+import { CloudWatchAnnotationType, CloudWatchJsonData, CloudWatchQuery, LogsQueryLanguage, MetricStat } from '../../types';
+import { LogsQLCodeEditor } from '../QueryEditor/LogsQueryEditor/code-editors/LogsQLCodeEditor';
+import { LogGroupsFieldWrapper } from '../shared/LogGroups/LogGroupsField';
 import { MetricStatEditor } from '../shared/MetricStatEditor/MetricStatEditor';
 
 export type Props = QueryEditorProps<CloudWatchDatasource, CloudWatchQuery, CloudWatchJsonData>;
+
+const annotationTypeOptions: Array<SelectableValue<CloudWatchAnnotationType>> = [
+  { label: 'CloudWatch Metrics', value: 'metrics', description: 'Query CloudWatch alarms as annotations' },
+  { label: 'CloudWatch Logs', value: 'logs', description: 'Query log events as annotations' },
+];
 
 // Dashboard Settings -> Annotations -> New Query
 export const AnnotationQueryEditor = (props: Props) => {
@@ -25,6 +33,42 @@ export const AnnotationQueryEditor = (props: Props) => {
     );
   }
 
+  const isLogsMode = isLogsAnnotationQuery(query);
+  // Default to metrics for backward compatibility
+  const annotationType = query.annotationType || 'metrics';
+
+  const onAnnotationTypeChange = (newType: CloudWatchAnnotationType) => {
+    if (newType === 'logs') {
+      onChange({
+        ...query,
+        annotationType: 'logs',
+        // Initialize logs fields with defaults
+        expression: query.expression || DEFAULT_CWLI_QUERY_STRING,
+        logGroups: query.logGroups || [],
+        queryLanguage: query.queryLanguage || LogsQueryLanguage.CWLI,
+        // Clear metrics-specific fields
+        namespace: undefined,
+        metricName: undefined,
+        dimensions: undefined,
+        statistic: undefined,
+        period: undefined,
+        actionPrefix: undefined,
+        alarmNamePrefix: undefined,
+        prefixMatching: undefined,
+      });
+    } else {
+      onChange({
+        ...query,
+        annotationType: 'metrics',
+        // Clear logs-specific fields
+        expression: undefined,
+        logGroups: undefined,
+        logGroupNames: undefined,
+        queryLanguage: undefined,
+      });
+    }
+  };
+
   return (
     <>
       <EditorHeader>
@@ -37,52 +81,83 @@ export const AnnotationQueryEditor = (props: Props) => {
           options={regions}
           isLoading={regionIsLoading}
         />
+        <InlineSelect
+          aria-label="Annotation type"
+          label="Annotation type"
+          value={annotationType}
+          options={annotationTypeOptions}
+          onChange={({ value }) => value && onAnnotationTypeChange(value)}
+          inputId={`cloudwatch-annotation-type-${query.refId}`}
+          id={`cloudwatch-annotation-type-${query.refId}`}
+        />
       </EditorHeader>
       <Space v={0.5} />
-      <MetricStatEditor
-        {...props}
-        refId={query.refId}
-        metricStat={query}
-        disableExpressions={true}
-        onChange={(metricStat: MetricStat) => onChange({ ...query, ...metricStat })}
-      ></MetricStatEditor>
-      <Space v={0.5} />
-      <EditorRow>
-        <EditorField label="Period" width={26} tooltip="Minimum interval between points in seconds.">
-          <Input
-            value={query.period || ''}
-            placeholder="auto"
-            onChange={(event: ChangeEvent<HTMLInputElement>) => onChange({ ...query, period: event.target.value })}
-          />
-        </EditorField>
-        <EditorField label="Enable Prefix Matching" optional={true}>
-          <EditorSwitch
-            value={query.prefixMatching}
-            onChange={(e) => {
-              onChange({
-                ...query,
-                prefixMatching: e.currentTarget.checked,
-              });
+      {isLogsMode ? (
+        <>
+          <LogGroupsFieldWrapper
+            region={query.region}
+            datasource={datasource}
+            // eslint-disable-next-line @typescript-eslint/no-deprecated
+            legacyLogGroupNames={query.logGroupNames}
+            logGroups={query.logGroups}
+            onChange={(logGroups) => {
+              onChange({ ...query, logGroups, logGroupNames: undefined });
+            }}
+            //legacy props
+            legacyOnChange={(logGroupNames) => {
+              onChange({ ...query, logGroupNames });
             }}
           />
-        </EditorField>
-        <EditorField label="Action" optional={true} disabled={!query.prefixMatching}>
-          <Input
-            value={query.actionPrefix || ''}
-            onChange={(event: ChangeEvent<HTMLInputElement>) =>
-              onChange({ ...query, actionPrefix: event.target.value })
-            }
-          />
-        </EditorField>
-        <EditorField label="Alarm Name" optional={true} disabled={!query.prefixMatching}>
-          <Input
-            value={query.alarmNamePrefix || ''}
-            onChange={(event: ChangeEvent<HTMLInputElement>) =>
-              onChange({ ...query, alarmNamePrefix: event.target.value })
-            }
-          />
-        </EditorField>
-      </EditorRow>
+          <LogsQLCodeEditor query={query} datasource={datasource} onChange={onChange} />
+        </>
+      ) : (
+        <>
+          <MetricStatEditor
+            {...props}
+            refId={query.refId}
+            metricStat={query as MetricStat}
+            disableExpressions={true}
+            onChange={(metricStat: MetricStat) => onChange({ ...query, ...metricStat })}
+          ></MetricStatEditor>
+          <Space v={0.5} />
+          <EditorRow>
+            <EditorField label="Period" width={26} tooltip="Minimum interval between points in seconds.">
+              <Input
+                value={query.period || ''}
+                placeholder="auto"
+                onChange={(event: ChangeEvent<HTMLInputElement>) => onChange({ ...query, period: event.target.value })}
+              />
+            </EditorField>
+            <EditorField label="Enable Prefix Matching" optional={true}>
+              <EditorSwitch
+                value={query.prefixMatching}
+                onChange={(e) => {
+                  onChange({
+                    ...query,
+                    prefixMatching: e.currentTarget.checked,
+                  });
+                }}
+              />
+            </EditorField>
+            <EditorField label="Action" optional={true} disabled={!query.prefixMatching}>
+              <Input
+                value={query.actionPrefix || ''}
+                onChange={(event: ChangeEvent<HTMLInputElement>) =>
+                  onChange({ ...query, actionPrefix: event.target.value })
+                }
+              />
+            </EditorField>
+            <EditorField label="Alarm Name" optional={true} disabled={!query.prefixMatching}>
+              <Input
+                value={query.alarmNamePrefix || ''}
+                onChange={(event: ChangeEvent<HTMLInputElement>) =>
+                  onChange({ ...query, alarmNamePrefix: event.target.value })
+                }
+              />
+            </EditorField>
+          </EditorRow>
+        </>
+      )}
     </>
   );
 };

--- a/src/dataquery.cue
+++ b/src/dataquery.cue
@@ -182,15 +182,34 @@ composableKinds: DataQuery: {
 
 				#CloudWatchQueryMode: "Metrics" | "Logs" | "Annotations" @cuetsy(kind="type")
 
+				#CloudWatchAnnotationType: "metrics" | "logs" @cuetsy(kind="type")
+
 				// Shape of a CloudWatch Annotation query
 				#CloudWatchAnnotationQuery: {
 					common.DataQuery
-					#MetricStat
 
 					// Whether a query is a Metrics, Logs, or Annotations query
 					queryMode: #CloudWatchQueryMode
-					// Enable matching on the prefix of the action name or alarm name, specify the prefixes with actionPrefix and/or alarmNamePrefix
-					prefixMatching?: bool
+					// The type of annotation query - metrics (alarms) or logs (log events)
+					annotationType?: #CloudWatchAnnotationType
+					// AWS region to query for the annotations
+					region: string
+
+					// ===== Metrics Annotation Fields (CloudWatch Alarms) =====
+					// The ID of the AWS account to query for the metric, specifying `all` will query all accounts that the monitoring account is permitted to query.
+					accountId?: string
+					// A namespace is a container for CloudWatch metrics. Metrics in different namespaces are isolated from each other, so that metrics from different applications are not mistakenly aggregated into the same statistics. For example, Amazon EC2 uses the AWS/EC2 namespace.
+					namespace?: string
+					// Name of the metric
+					metricName?: string
+					// The dimensions of the metric
+					dimensions?: #Dimensions
+					// Only show metrics that exactly match all defined dimension names.
+					matchExact?: bool
+					// Metric data aggregations over specified periods of time. For detailed definitions of the statistics supported by CloudWatch, see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Statistics-definitions.html.
+					statistic?: string
+					// The length of time associated with a specific Amazon CloudWatch statistic. Can be specified by a number of seconds, 'auto', or as a duration string e.g. '15m' being 15 minutes
+					period?: string
 					// Use this parameter to filter the results of the operation to only those alarms
 					// that use a certain alarm action. For example, you could specify the ARN of
 					// an SNS topic to find all alarms that send notifications to that topic.
@@ -201,6 +220,18 @@ composableKinds: DataQuery: {
 					// about all alarms that have names that start with this prefix.
 					// e.g. `my-team-service-` would match `my-team-service-high-cpu` but not match `your-team-service-high-cpu`
 					alarmNamePrefix?: string
+					// Enable matching on the prefix of the action name or alarm name, specify the prefixes with actionPrefix and/or alarmNamePrefix
+					prefixMatching?: bool
+
+					// ===== Logs Annotation Fields (CloudWatch Logs Insights) =====
+					// The CloudWatch Logs Insights query to execute
+					expression?: string
+					// Log groups to query
+					logGroups?: [...#LogGroup]
+					// @deprecated use logGroups
+					logGroupNames?: [...string]
+					// Language used for querying logs, can be CWLI, SQL, or PPL. If empty, the default language is CWLI.
+					queryLanguage?: #LogsQueryLanguage
 				} @cuetsy(kind="interface")
 
 				// TS type is CloudWatchDefaultQuery = Omit<CloudWatchLogsQuery, 'queryMode'> & CloudWatchMetricsQuery, declared in veneer

--- a/src/dataquery.ts
+++ b/src/dataquery.ts
@@ -314,6 +314,8 @@ export interface LogGroup {
   name: string;
 }
 
+export type CloudWatchAnnotationType = 'metrics' | 'logs';
+
 /**
  * Shape of a CloudWatch Annotation query
  */
@@ -321,7 +323,49 @@ export interface LogGroup {
  * TS type is CloudWatchDefaultQuery = Omit<CloudWatchLogsQuery, 'queryMode'> & CloudWatchMetricsQuery, declared in veneer
  * #CloudWatchDefaultQuery: #CloudWatchLogsQuery & #CloudWatchMetricsQuery @cuetsy(kind="type")
  */
-export interface CloudWatchAnnotationQuery extends common.DataQuery, MetricStat {
+export interface CloudWatchAnnotationQuery extends common.DataQuery {
+  /**
+   * The type of annotation query - metrics (alarms) or logs (log events)
+   */
+  annotationType?: CloudWatchAnnotationType;
+  /**
+   * Whether a query is a Metrics, Logs, or Annotations query
+   */
+  queryMode: CloudWatchQueryMode;
+  /**
+   * AWS region to query for the annotations
+   */
+  region: string;
+
+  // ===== Metrics Annotation Fields (CloudWatch Alarms) =====
+  /**
+   * The ID of the AWS account to query for the metric, specifying `all` will query all accounts that the monitoring account is permitted to query.
+   */
+  accountId?: string;
+  /**
+   * A namespace is a container for CloudWatch metrics. Metrics in different namespaces are isolated from each other, so that metrics from different applications are not mistakenly aggregated into the same statistics. For example, Amazon EC2 uses the AWS/EC2 namespace.
+   */
+  namespace?: string;
+  /**
+   * Name of the metric
+   */
+  metricName?: string;
+  /**
+   * The dimensions of the metric
+   */
+  dimensions?: Dimensions;
+  /**
+   * Only show metrics that exactly match all defined dimension names.
+   */
+  matchExact?: boolean;
+  /**
+   * Metric data aggregations over specified periods of time. For detailed definitions of the statistics supported by CloudWatch, see https://docs.aws.amazon.com/AmazonCloudWatch/latest/monitoring/Statistics-definitions.html.
+   */
+  statistic?: string;
+  /**
+   * The length of time associated with a specific Amazon CloudWatch statistic. Can be specified by a number of seconds, 'auto', or as a duration string e.g. '15m' being 15 minutes
+   */
+  period?: string;
   /**
    * Use this parameter to filter the results of the operation to only those alarms
    * that use a certain alarm action. For example, you could specify the ARN of
@@ -340,10 +384,28 @@ export interface CloudWatchAnnotationQuery extends common.DataQuery, MetricStat 
    * Enable matching on the prefix of the action name or alarm name, specify the prefixes with actionPrefix and/or alarmNamePrefix
    */
   prefixMatching?: boolean;
+
+  // ===== Logs Annotation Fields (CloudWatch Logs Insights) =====
   /**
-   * Whether a query is a Metrics, Logs, or Annotations query
+   * The CloudWatch Logs Insights query to execute
    */
-  queryMode: CloudWatchQueryMode;
+  expression?: string;
+  /**
+   * Log groups to query
+   */
+  logGroups?: LogGroup[];
+  /**
+   * @deprecated use logGroups
+   */
+  logGroupNames?: string[];
+  /**
+   * Language used for querying logs, can be CWLI, SQL, or PPL. If empty, the default language is CWLI.
+   */
+  queryLanguage?: LogsQueryLanguage;
+  /**
+   * Whether a query is a Logs Insights or Log Anomalies query
+   */
+  logsMode?: LogsMode;
 }
 
 export interface CloudWatchDataQuery {}

--- a/src/defaultQueries.ts
+++ b/src/defaultQueries.ts
@@ -29,6 +29,7 @@ export const DEFAULT_METRICS_QUERY: Omit<CloudWatchMetricsQuery, 'refId'> = {
 
 export const DEFAULT_ANNOTATIONS_QUERY: Omit<CloudWatchAnnotationQuery, 'refId'> = {
   queryMode: 'Annotations',
+  annotationType: 'metrics', // Default to metrics for backward compatibility
   namespace: '',
   region: 'default',
   statistic: 'Average',

--- a/src/guards.test.ts
+++ b/src/guards.test.ts
@@ -1,0 +1,186 @@
+import { CloudWatchAnnotationQuery, CloudWatchLogsQuery, CloudWatchMetricsQuery, CloudWatchQuery } from './types';
+import { isLogsAnnotationQuery, isMetricsAnnotationQuery, isCloudWatchAnnotationQuery } from './guards';
+
+describe('Annotation Query Guards', () => {
+  describe('isMetricsAnnotationQuery', () => {
+    it('should return true when annotationType is "metrics"', () => {
+      const query: CloudWatchAnnotationQuery = {
+        refId: 'A',
+        queryMode: 'Annotations',
+        annotationType: 'metrics',
+        region: 'us-east-1',
+        namespace: 'AWS/EC2',
+        metricName: 'CPUUtilization',
+        statistic: 'Average',
+      };
+
+      expect(isMetricsAnnotationQuery(query)).toBe(true);
+    });
+
+    it('should return true when annotationType is undefined (backward compatibility)', () => {
+      const query: CloudWatchAnnotationQuery = {
+        refId: 'A',
+        queryMode: 'Annotations',
+        region: 'us-east-1',
+        namespace: 'AWS/EC2',
+        metricName: 'CPUUtilization',
+        statistic: 'Average',
+      };
+
+      expect(isMetricsAnnotationQuery(query)).toBe(true);
+    });
+
+    it('should return false when annotationType is "logs"', () => {
+      const query: CloudWatchAnnotationQuery = {
+        refId: 'A',
+        queryMode: 'Annotations',
+        annotationType: 'logs',
+        region: 'us-east-1',
+        expression: 'fields @timestamp, @message',
+        logGroups: [],
+      };
+
+      expect(isMetricsAnnotationQuery(query)).toBe(false);
+    });
+
+    it('should return false for non-annotation queries', () => {
+      const metricsQuery: CloudWatchMetricsQuery = {
+        refId: 'A',
+        id: '',
+        queryMode: 'Metrics',
+        region: 'us-east-1',
+        namespace: 'AWS/EC2',
+        metricName: 'CPUUtilization',
+        statistic: 'Average',
+        period: '',
+        expression: '',
+        dimensions: {},
+      };
+
+      expect(isMetricsAnnotationQuery(metricsQuery)).toBe(false);
+    });
+
+    it('should return false for logs queries', () => {
+      const logsQuery: CloudWatchLogsQuery = {
+        refId: 'A',
+        id: '',
+        queryMode: 'Logs',
+        region: 'us-east-1',
+        expression: 'fields @timestamp',
+        logGroups: [],
+      };
+
+      expect(isMetricsAnnotationQuery(logsQuery)).toBe(false);
+    });
+  });
+
+  describe('isLogsAnnotationQuery', () => {
+    it('should return true when annotationType is "logs"', () => {
+      const query: CloudWatchAnnotationQuery = {
+        refId: 'A',
+        queryMode: 'Annotations',
+        annotationType: 'logs',
+        region: 'us-east-1',
+        expression: 'fields @timestamp, @message',
+        logGroups: [],
+      };
+
+      expect(isLogsAnnotationQuery(query)).toBe(true);
+    });
+
+    it('should return false when annotationType is "metrics"', () => {
+      const query: CloudWatchAnnotationQuery = {
+        refId: 'A',
+        queryMode: 'Annotations',
+        annotationType: 'metrics',
+        region: 'us-east-1',
+        namespace: 'AWS/EC2',
+        metricName: 'CPUUtilization',
+        statistic: 'Average',
+      };
+
+      expect(isLogsAnnotationQuery(query)).toBe(false);
+    });
+
+    it('should return false when annotationType is undefined', () => {
+      const query: CloudWatchAnnotationQuery = {
+        refId: 'A',
+        queryMode: 'Annotations',
+        region: 'us-east-1',
+        namespace: 'AWS/EC2',
+        metricName: 'CPUUtilization',
+        statistic: 'Average',
+      };
+
+      expect(isLogsAnnotationQuery(query)).toBe(false);
+    });
+
+    it('should return false for non-annotation queries', () => {
+      const metricsQuery: CloudWatchMetricsQuery = {
+        refId: 'A',
+        id: '',
+        queryMode: 'Metrics',
+        region: 'us-east-1',
+        namespace: 'AWS/EC2',
+        metricName: 'CPUUtilization',
+        statistic: 'Average',
+        period: '',
+        expression: '',
+        dimensions: {},
+      };
+
+      expect(isLogsAnnotationQuery(metricsQuery)).toBe(false);
+    });
+
+    it('should return false for logs queries', () => {
+      const logsQuery: CloudWatchLogsQuery = {
+        refId: 'A',
+        id: '',
+        queryMode: 'Logs',
+        region: 'us-east-1',
+        expression: 'fields @timestamp',
+        logGroups: [],
+      };
+
+      expect(isLogsAnnotationQuery(logsQuery)).toBe(false);
+    });
+  });
+
+  describe('Type Narrowing', () => {
+    it('should narrow type correctly for metrics annotations', () => {
+      const query: CloudWatchQuery = {
+        refId: 'A',
+        queryMode: 'Annotations',
+        annotationType: 'metrics',
+        region: 'us-east-1',
+        namespace: 'AWS/EC2',
+        metricName: 'CPUUtilization',
+        statistic: 'Average',
+      } as CloudWatchAnnotationQuery;
+
+      if (isMetricsAnnotationQuery(query)) {
+        // Should have access to metrics annotation properties
+        expect(query.namespace).toBe('AWS/EC2');
+        expect(query.metricName).toBe('CPUUtilization');
+        expect(query.statistic).toBe('Average');
+      }
+    });
+
+    it('should narrow type correctly for logs annotations', () => {
+      const query: CloudWatchQuery = {
+        refId: 'A',
+        queryMode: 'Annotations',
+        annotationType: 'logs',
+        region: 'us-east-1',
+        expression: 'fields @timestamp, @message',
+        logGroups: [],
+      } as CloudWatchAnnotationQuery;
+
+      if (isLogsAnnotationQuery(query)) {
+        // Should have access to logs annotation properties
+        expect(query.expression).toBe('fields @timestamp, @message');
+        expect(query.logGroups).toEqual([]);
+      }
+    });
+  });
+});

--- a/src/guards.ts
+++ b/src/guards.ts
@@ -28,5 +28,20 @@ export const isCloudWatchAnnotationQuery = (
   cloudwatchQuery: CloudWatchQuery
 ): cloudwatchQuery is CloudWatchAnnotationQuery => cloudwatchQuery.queryMode === 'Annotations';
 
+export const isMetricsAnnotationQuery = (query: CloudWatchQuery): query is CloudWatchAnnotationQuery => {
+  if (!isCloudWatchAnnotationQuery(query)) {
+    return false;
+  }
+  // Default to metrics for backward compatibility (when annotationType is not set)
+  return !query.annotationType || query.annotationType === 'metrics';
+};
+
+export const isLogsAnnotationQuery = (query: CloudWatchQuery): query is CloudWatchAnnotationQuery => {
+  if (!isCloudWatchAnnotationQuery(query)) {
+    return false;
+  }
+  return query.annotationType === 'logs';
+};
+
 export const isCloudWatchAnnotation = (query: unknown): query is AnnotationQuery<CloudWatchAnnotationQuery> =>
   (query as AnnotationQuery<CloudWatchAnnotationQuery>).target?.queryMode === 'Annotations';

--- a/src/query-runner/CloudWatchAnnotationQueryRunner.test.ts
+++ b/src/query-runner/CloudWatchAnnotationQueryRunner.test.ts
@@ -38,4 +38,121 @@ describe('CloudWatchAnnotationQueryRunner', () => {
       );
     });
   });
+
+  describe('Logs Annotation Query', () => {
+    const logsQueries: CloudWatchAnnotationQuery[] = [
+      {
+        queryMode: 'Annotations',
+        annotationType: 'logs',
+        refId: 'Anno',
+        region: `$${regionVariable.name}`,
+        expression: 'fields @timestamp, @message | filter @message like /$logFilter/',
+        logGroups: [
+          {
+            arn: 'arn:aws:logs:us-east-1:123456789012:log-group:/aws/lambda/test',
+            name: '/aws/lambda/test',
+          },
+        ],
+        queryLanguage: 'CWLI',
+      },
+    ];
+
+    it('should issue the correct logs annotation query', async () => {
+      const { runner, queryMock, request } = setupMockedAnnotationQueryRunner({
+        variables: [regionVariable],
+      });
+      await expect(runner.handleAnnotationQuery(logsQueries, request, queryMock)).toEmitValuesWith(() => {
+        expect(queryMock.mock.calls[0][0].targets[0]).toMatchObject(
+          expect.objectContaining({
+            region: regionVariable.current.value,
+            expression: logsQueries[0].expression,
+            logGroups: logsQueries[0].logGroups,
+            queryLanguage: 'CWLI',
+          })
+        );
+      });
+    });
+
+    it('should apply template variable interpolation to expression', async () => {
+      const logFilterVariable = {
+        name: 'logFilter',
+        current: { value: 'ERROR', text: 'ERROR' },
+      };
+
+      const queriesWithVars: CloudWatchAnnotationQuery[] = [
+        {
+          ...logsQueries[0],
+          expression: 'fields @timestamp, @message | filter @message like /$logFilter/',
+        },
+      ];
+
+      const { runner, queryMock, request } = setupMockedAnnotationQueryRunner({
+        variables: [regionVariable, logFilterVariable],
+      });
+
+      await expect(runner.handleAnnotationQuery(queriesWithVars, request, queryMock)).toEmitValuesWith(() => {
+        const target = queryMock.mock.calls[0][0].targets[0];
+        expect(target.expression).toBe('fields @timestamp, @message | filter @message like /ERROR/');
+      });
+    });
+
+    it('should include logGroups array', async () => {
+      const { runner, queryMock, request } = setupMockedAnnotationQueryRunner({
+        variables: [regionVariable],
+      });
+      await expect(runner.handleAnnotationQuery(logsQueries, request, queryMock)).toEmitValuesWith(() => {
+        const target = queryMock.mock.calls[0][0].targets[0];
+        expect(target.logGroups).toEqual(logsQueries[0].logGroups);
+        expect(target.logGroups).toHaveLength(1);
+        expect(target.logGroups[0].name).toBe('/aws/lambda/test');
+      });
+    });
+
+    it('should not include metrics-specific fields for logs annotations', async () => {
+      const { runner, queryMock, request } = setupMockedAnnotationQueryRunner({
+        variables: [regionVariable],
+      });
+      await expect(runner.handleAnnotationQuery(logsQueries, request, queryMock)).toEmitValuesWith(() => {
+        const target = queryMock.mock.calls[0][0].targets[0];
+        expect(target.namespace).toBeUndefined();
+        expect(target.metricName).toBeUndefined();
+        expect(target.statistic).toBeUndefined();
+        expect(target.dimensions).toBeUndefined();
+        expect(target.period).toBeUndefined();
+        expect(target.actionPrefix).toBeUndefined();
+        expect(target.alarmNamePrefix).toBeUndefined();
+      });
+    });
+  });
+
+  describe('Backward Compatibility', () => {
+    it('should handle annotation queries without annotationType field (defaults to metrics)', async () => {
+      const queriesWithoutType: CloudWatchAnnotationQuery[] = [
+        {
+          // No annotationType field - should default to metrics
+          datasource: { type: 'cloudwatch' },
+          dimensions: { InstanceId: 'i-12345678' },
+          matchExact: true,
+          metricName: 'CPUUtilization',
+          period: '300',
+          prefixMatching: false,
+          queryMode: 'Annotations',
+          refId: 'Anno',
+          namespace: 'AWS/EC2',
+          region: 'us-east-1',
+          statistic: 'Average',
+        },
+      ];
+
+      const { runner, queryMock, request} = setupMockedAnnotationQueryRunner({
+        variables: [],
+      });
+      await expect(runner.handleAnnotationQuery(queriesWithoutType, request, queryMock)).toEmitValuesWith(() => {
+        const target = queryMock.mock.calls[0][0].targets[0];
+        expect(target.namespace).toBe('AWS/EC2');
+        expect(target.metricName).toBe('CPUUtilization');
+        expect(target.statistic).toBe('Average');
+      });
+    });
+  });
 });

--- a/src/query-runner/CloudWatchAnnotationQueryRunner.ts
+++ b/src/query-runner/CloudWatchAnnotationQueryRunner.ts
@@ -3,6 +3,7 @@ import { Observable } from 'rxjs';
 import { DataQueryRequest, DataQueryResponse, DataSourceInstanceSettings } from '@grafana/data';
 import { TemplateSrv } from '@grafana/runtime';
 
+import { isLogsAnnotationQuery } from '../guards';
 import { CloudWatchAnnotationQuery, CloudWatchJsonData, CloudWatchQuery } from '../types';
 
 import { CloudWatchRequest } from './CloudWatchRequest';
@@ -20,19 +21,37 @@ export class CloudWatchAnnotationQueryRunner extends CloudWatchRequest {
   ): Observable<DataQueryResponse> {
     return queryFn({
       ...options,
-      targets: queries.map((query) => ({
-        ...query,
-        statistic: this.templateSrv.replace(query.statistic),
-        region: this.templateSrv.replace(this.getActualRegion(query.region)),
-        namespace: this.templateSrv.replace(query.namespace),
-        metricName: this.templateSrv.replace(query.metricName),
-        dimensions: this.convertDimensionFormat(query.dimensions ?? {}, {}),
-        period: query.period ?? '',
-        actionPrefix: query.actionPrefix ?? '',
-        alarmNamePrefix: query.alarmNamePrefix ?? '',
-        type: 'annotationQuery',
-        datasource: this.ref,
-      })),
+      targets: queries.map((query) => {
+        const baseQuery = {
+          ...query,
+          region: this.templateSrv.replace(this.getActualRegion(query.region)),
+          type: 'annotationQuery',
+          datasource: this.ref,
+        };
+
+        // Handle logs annotations
+        if (isLogsAnnotationQuery(query)) {
+          return {
+            ...baseQuery,
+            expression: this.templateSrv.replace(query.expression ?? ''),
+            logGroups: query.logGroups || [],
+            logGroupNames: query.logGroupNames || [],
+            queryLanguage: query.queryLanguage,
+          };
+        }
+
+        // Handle metrics annotations (default for backward compatibility)
+        return {
+          ...baseQuery,
+          statistic: this.templateSrv.replace(query.statistic),
+          namespace: this.templateSrv.replace(query.namespace),
+          metricName: this.templateSrv.replace(query.metricName),
+          dimensions: this.convertDimensionFormat(query.dimensions ?? {}, {}),
+          period: query.period ?? '',
+          actionPrefix: query.actionPrefix ?? '',
+          alarmNamePrefix: query.alarmNamePrefix ?? '',
+        };
+      }),
     });
   }
 }


### PR DESCRIPTION
Work in progress sorry

I noticed that I can't use the query type 'logs' in the annotations query view, unlike in the usual query view elsewhere:

<img width="2546" height="1380" alt="screenshot 2025-11-18 at 13 11 48@2x" src="https://github.com/user-attachments/assets/dc8422ae-9473-4635-b744-3c9d10238402" />

> explore (default query view)

<img width="4074" height="2614" alt="screenshot 2025-11-18 at 13 12 32@2x" src="https://github.com/user-attachments/assets/6b297240-48a0-4746-9f08-582acc99a305" />

> annotations (limited in fieldset choice)