### PR TITLE
skip dev images for e2e tests

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -42,3 +42,4 @@ jobs:
       go-version: '1.24'
       golangci-lint-version: '2.1.6'
       github-draft-release: false # publish the github release directly, skipping the draft
+      run-playwright-with-skip-grafana-dev-image: true

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -17,3 +17,4 @@ jobs:
     with:
       plugin-version-suffix: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}
       golangci-lint-version: '2.0.2'
+      run-playwright-with-skip-grafana-dev-image: true


### PR DESCRIPTION
temporarily skipping dev images for e2e tests. see slack thread for more context https://raintank-corp.slack.com/archives/C05FYAPEPKP/p1763670118775519

for reference, the failing test is only for a recent 12.4.0 dev image: https://github.com/grafana/grafana-cloudwatch-datasource/actions/runs/19544216646/job/55963295996