### PR TITLE
chore(deps): update go version to 1.26.1

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/grafana/grafana-cloudwatch-datasource
 
-go 1.25.7
+go 1.26.1
 
 require (
 	github.com/aws/aws-sdk-go-v2 v1.41.4


### PR DESCRIPTION
- Resolve [GHSA-p77j-4mvh-x3m3](https://nvd.nist.gov/vuln/detail/CVE-2026-33186) critical vulnerability (affects gRPC-Go versions before v1.79.3
- Resolve [CVE-2026-25679](https://nvd.nist.gov/vuln/detail/CVE-2026-24679) high vulnerability (URL parsing in Go stdlib pre `1.25.8`)