### PR TITLE
Add session token handling for auth service support

### DIFF
--- a/pkg/cloudwatch/cloudwatch.go
+++ b/pkg/cloudwatch/cloudwatch.go
@@ -78,6 +78,7 @@ func (ds *DataSource) newAWSConfig(ctx context.Context, region string) (aws.Conf
 		Region:             region,
 		AccessKey:          ds.Settings.AccessKey,
 		SecretKey:          ds.Settings.SecretKey,
+		SessionToken:       ds.Settings.SessionToken,
 		HTTPClient:         &http.Client{},
 	}
 	if ds.Settings.GrafanaSettings.SecureSocksDSProxyEnabled && ds.Settings.SecureSocksProxyEnabled {

--- a/pkg/cloudwatch/cloudwatch_test.go
+++ b/pkg/cloudwatch/cloudwatch_test.go
@@ -223,6 +223,30 @@ func TestGetAWSConfig_passes_authSettings(t *testing.T) {
 	require.NoError(t, err)
 }
 
+type spyConfigProvider struct {
+	captured awsauth.Settings
+}
+
+func (s *spyConfigProvider) GetConfig(_ context.Context, settings awsauth.Settings) (aws.Config, error) {
+	s.captured = settings
+	return aws.Config{}, nil
+}
+
+func TestNewAWSConfig_passesSessionToken(t *testing.T) {
+	spy := &spyConfigProvider{}
+	ds := newTestDatasource(func(ds *DataSource) {
+		ds.AWSConfigProvider = spy
+		ds.Settings.AuthType = awsds.AuthTypeKeys
+		ds.Settings.AccessKey = "AKIAIOSFODNN7EXAMPLE"
+		ds.Settings.SecretKey = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+		ds.Settings.SessionToken = "AQoDYXdzEJr//test-session-token"
+	})
+
+	_, err := ds.newAWSConfig(context.Background(), "us-east-1")
+	require.NoError(t, err)
+	assert.Equal(t, "AQoDYXdzEJr//test-session-token", spy.captured.SessionToken)
+}
+
 func TestQuery_ResourceRequest_DescribeLogGroups_with_CrossAccountQuerying(t *testing.T) {
 	sender := &mockedCallResourceResponseSenderForOauth{}
 	origNewMetricsAPI := NewCWClient

--- a/pkg/cloudwatch/models/settings_test.go
+++ b/pkg/cloudwatch/models/settings_test.go
@@ -227,6 +227,22 @@ func Test_Settings_LoadCloudWatchSettings(t *testing.T) {
 		require.Error(t, err)
 	})
 
+	t.Run("Should load sessionToken from secureJSONData", func(t *testing.T) {
+		settings := backend.DataSourceInstanceSettings{
+			ID:       33,
+			JSONData: []byte(`{"authType": "keys", "defaultRegion": "us-east-1"}`),
+			DecryptedSecureJSONData: map[string]string{
+				"accessKey":    "AKIAIOSFODNN7EXAMPLE",
+				"secretKey":    "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY",
+				"sessionToken": "AQoDYXdzEJr//test-session-token",
+			},
+		}
+
+		s, err := LoadCloudWatchSettings(settingCtx, settings)
+		require.NoError(t, err)
+		assert.Equal(t, "AQoDYXdzEJr//test-session-token", s.SessionToken)
+	})
+
 	t.Run("Should load settings from context", func(t *testing.T) {
 		settingCtx := backend.WithGrafanaConfig(context.Background(), backend.NewGrafanaCfg(map[string]string{
 			awsds.AllowedAuthProvidersEnvVarKeyName:  "foo , bar,baz",


### PR DESCRIPTION
To enable Grafana Assume Role via the auth service we need to forward the passed-in SessionToken.