### PR TITLE
feat(logs): add new CloudWatch Logs Insights commands and functions

### DIFF
--- a/src/language/cloudwatch-logs/syntax.ts
+++ b/src/language/cloudwatch-logs/syntax.ts
@@ -23,6 +23,22 @@ export const QUERY_COMMANDS: CompletionItem[] = [
     documentation:
       'Extracts data from a log field, creating one or more ephemeral fields that you can process further in the query',
   },
+  {
+    label: 'lookup',
+    documentation: 'Cross-reference log fields with a lookup table for enrichment. Example: | lookup accountId from "account-names"',
+  },
+  {
+    label: 'join',
+    documentation: 'Join results from multiple log groups on a common field. Example: | join "/aws/lambda/auth" as auth on requestId',
+  },
+  {
+    label: 'expand',
+    documentation: 'Expand nested JSON fields into top-level queryable fields. Example: | expand metadata',
+  },
+  {
+    label: 'relevantfields',
+    documentation: 'Display the most relevant fields for filtered results. Must follow a filter clause.',
+  },
 ];
 
 export const COMPARISON_OPERATORS = ['=', '!=', '<', '<=', '>', '>='];
@@ -64,6 +80,16 @@ export const NUMERIC_OPERATORS = [
     detail: 'sqrt(a)',
     documentation: 'Square root.',
   },
+  {
+    label: 'round',
+    detail: 'round(a)',
+    documentation: 'Rounds a numeric value to the nearest integer.',
+  },
+  {
+    label: 'haversine',
+    detail: 'haversine(lat1, lon1, lat2, lon2)',
+    documentation: 'Calculates the great-circle distance between two geographic coordinates in kilometers.',
+  },
 ];
 
 export const GENERAL_FUNCTIONS = [
@@ -76,6 +102,31 @@ export const GENERAL_FUNCTIONS = [
     label: 'coalesce',
     detail: 'coalesce(fieldname1, fieldname2, ... fieldnamex)',
     documentation: 'Returns the first non-null value from the list.',
+  },
+  {
+    label: 'case',
+    detail: 'case(condition1, value1, ..., default)',
+    documentation: 'Evaluates conditions in order, returns value for first true condition. Last argument is default. Example: fields case(statusCode >= 500, "error", statusCode >= 400, "warn", "ok") as severity',
+  },
+  {
+    label: 'base64encode',
+    detail: 'base64encode(field)',
+    documentation: 'Encodes a field value to Base64 representation.',
+  },
+  {
+    label: 'base64decode',
+    detail: 'base64decode(field)',
+    documentation: 'Decodes a Base64-encoded field value back to plaintext.',
+  },
+  {
+    label: 'urlencode',
+    detail: 'urlencode(field)',
+    documentation: 'URL-encodes a field value (percent-encoding).',
+  },
+  {
+    label: 'urldecode',
+    detail: 'urldecode(field)',
+    documentation: 'Decodes a URL-encoded (percent-encoded) field value.',
   },
 ];
 
@@ -143,6 +194,21 @@ export const STRING_FUNCTIONS = [
     label: 'strcontains',
     detail: 'strcontains(string1, string2)',
     documentation: 'Returns 1 if string1 contains string2 and 0 otherwise.',
+  },
+  {
+    label: 'startswith',
+    detail: 'startswith(field, prefix)',
+    documentation: 'Returns true if the field value starts with the specified string. Example: filter startswith(url, "/api/v2")',
+  },
+  {
+    label: 'endswith',
+    detail: 'endswith(field, suffix)',
+    documentation: 'Returns true if the field value ends with the specified string. Example: filter endswith(path, ".json")',
+  },
+  {
+    label: 'regex_replace',
+    detail: 'regex_replace(field, pattern, replacement)',
+    documentation: 'Replaces occurrences matching a regex pattern with the replacement string.',
   },
 ];
 

--- a/src/language/logs/language.ts
+++ b/src/language/logs/language.ts
@@ -18,8 +18,12 @@ export const LIMIT = 'limit';
 export const PARSE = 'parse';
 export const DEDUP = 'dedup';
 export const ANOMALY = 'anomaly';
+export const LOOKUP = 'lookup';
+export const JOIN = 'join';
+export const EXPAND = 'expand';
+export const RELEVANTFIELDS = 'relevantfields';
 
-export const LOGS_COMMANDS = [DISPLAY, FIELDS, FILTER, PATTERN, STATS, SORT, LIMIT, PARSE, DEDUP, DIFF, ANOMALY];
+export const LOGS_COMMANDS = [DISPLAY, FIELDS, FILTER, PATTERN, STATS, SORT, LIMIT, PARSE, DEDUP, DIFF, ANOMALY, LOOKUP, JOIN, EXPAND, RELEVANTFIELDS];
 
 export const LOGS_LOGIC_OPERATORS = ['and', 'or', 'not'];
 
@@ -32,6 +36,8 @@ export const LOGS_FUNCTION_OPERATORS = [
   'least',
   'log',
   'sqrt',
+  'round',
+  'haversine',
   // datetime
   'bin',
   'datefloor',
@@ -41,6 +47,7 @@ export const LOGS_FUNCTION_OPERATORS = [
   // general
   'ispresent',
   'coalesce',
+  'case',
   // ip
   'isValidIp',
   'isValidIpV4',
@@ -75,13 +82,24 @@ export const LOGS_FUNCTION_OPERATORS = [
   'substr',
   'replace',
   'strcontains',
+  'startswith',
+  'endswith',
+  'regex_replace',
+
+  // encoding
+  'base64encode',
+  'base64decode',
+  'urlencode',
+  'urldecode',
   // field
   'unmask',
 ];
 
 export const SORT_DIRECTION_KEYWORDS = ['asc', 'desc'];
 export const DIFF_MODIFIERS = ['previousDay', 'previousWeek', 'previousMonth'];
-export const LOGS_KEYWORDS = ['like', 'by', 'in', 'as', ...SORT_DIRECTION_KEYWORDS, ...DIFF_MODIFIERS];
+export const PARSE_FORMATS = ['logfmt'];
+
+export const LOGS_KEYWORDS = ['like', 'by', 'in', 'as', ...SORT_DIRECTION_KEYWORDS, ...DIFF_MODIFIERS, ...PARSE_FORMATS];
 
 export const language: CloudWatchLogsLanguage = {
   defaultToken: 'invalid',


### PR DESCRIPTION
Add autocomplete for recently launched CW Logs Insights features:
- Commands: lookup, join, expand, relevantfields
- Parse format: logfmt
- Functions: startswith, endswith, regex_replace, round, haversine,
  case, base64encode, base64decode, urlencode, urldecode

All features GA in all AWS regions (May 2026).

Signed-off-by: Sarthak Bhat <bhatsarthak@amazon.com>"