### PR TITLE
chore: update plugin-ci-workflows to v8.0.1

### DIFF
--- a/.github/workflows/publish.yaml
+++ b/.github/workflows/publish.yaml
@@ -30,7 +30,7 @@ jobs:
       pull-requests: read
       id-token: write
       attestations: write
-    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v6.1.1
+    uses: grafana/plugin-ci-workflows/.github/workflows/cd.yml@ci-cd-workflows/v8.0.1
     with:
       branch: ${{ github.event.inputs.branch }}
       environment: 'prod'

--- a/.github/workflows/push.yaml
+++ b/.github/workflows/push.yaml
@@ -13,6 +13,6 @@ jobs:
     permissions:
       contents: read
       id-token: write
-    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@ci-cd-workflows/v6.1.1
+    uses: grafana/plugin-ci-workflows/.github/workflows/ci.yml@ci-cd-workflows/v8.0.1
     with:
       plugin-version-suffix: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.sha || '' }}


### PR DESCRIPTION
## Summary
- Updates `grafana/plugin-ci-workflows` reusable workflows to the target version.
- This brings CI/CD pipelines in line with the latest plugin-ci-workflows release.

## Test plan
- [ ] Verify CI passes on this PR