### PR TITLE
feat(logs): add new CloudWatch Logs Insights commands and functions

### DIFF
--- a/src/language/cloudwatch-logs/syntax.ts
+++ b/src/language/cloudwatch-logs/syntax.ts
@@ -13,6 +13,10 @@ export const QUERY_COMMANDS: CompletionItem[] = [
     documentation: 'Filters the results of a query based on one or more conditions',
   },
   {
+    label: 'where',
+    documentation: 'Alias for the filter command; accepts identical syntax.',
+  },
+  {
     label: 'stats',
     documentation: 'Calculates aggregate statistics based on the values of log fields',
   },
@@ -22,6 +26,97 @@ export const QUERY_COMMANDS: CompletionItem[] = [
     label: 'parse',
     documentation:
       'Extracts data from a log field, creating one or more ephemeral fields that you can process further in the query',
+  },
+  {
+    label: 'pattern',
+    documentation: 'Automatically clusters your log data into shared text-structure patterns.',
+  },
+  {
+    label: 'dedup',
+    documentation: 'Removes duplicate results based on the values of the fields you specify.',
+  },
+  {
+    label: 'diff',
+    documentation:
+      'Compares the log events in the requested time period with those from a previous period of equal length.',
+  },
+  {
+    label: 'anomaly',
+    documentation: 'Identifies unusual patterns in your log data using machine learning.',
+  },
+  {
+    label: 'addtotals',
+    documentation: 'Computes row totals and column totals for numeric fields.',
+  },
+  {
+    label: 'relevantfields',
+    documentation: 'Displays the most relevant fields for filtered results. Must follow a filter clause.',
+  },
+  {
+    label: 'expand',
+    documentation: 'Expands nested JSON fields into top-level queryable fields.',
+  },
+  {
+    label: 'filterIndex',
+    documentation:
+      'Restricts the scan to log groups indexed on the specified field and containing its value, reducing scanned volume.',
+  },
+  {
+    label: 'unnest',
+    documentation: 'Flattens a list into multiple records, producing one record per element in the list.',
+  },
+  {
+    label: 'unmask',
+    documentation: 'Displays all content of a log event that was masked by a data protection policy.',
+  },
+  {
+    label: 'lookup',
+    documentation: 'Enriches log events with data from a lookup table by matching field values.',
+  },
+  {
+    label: 'join',
+    documentation:
+      'Combines log events from a source log group with events from another log group or query result on a matching field.',
+  },
+  {
+    label: 'autoregress',
+    documentation: "Creates lagged (previous-row) copies of a field's values.",
+  },
+  {
+    label: 'logcompare',
+    documentation: 'Compares the current time window against a baseline window shifted back by a duration.',
+  },
+  {
+    label: 'filldown',
+    documentation: 'Carries the last non-null value forward to fill gaps.',
+  },
+  {
+    label: 'fillmissing',
+    documentation: 'Inserts rows for empty time bins after stats by bin(), optionally filling fields with a constant.',
+  },
+  {
+    label: 'cidrlookup',
+    documentation: 'Enriches events by matching an IP field against CIDR ranges in a lookup table.',
+  },
+  {
+    label: 'outlier',
+    documentation: 'Detects statistical outliers based on the interquartile range (IQR).',
+  },
+  {
+    label: 'accum',
+    documentation: 'Computes a running cumulative sum of a numeric field.',
+  },
+  {
+    label: 'appendcols',
+    documentation: 'Appends columns from a sub-query to the current results by positional row matching.',
+  },
+  {
+    label: 'sessionize',
+    documentation: 'Groups events into sessions by identity fields and inactivity gap.',
+  },
+  {
+    label: 'countFrequent',
+    documentation: 'Returns an approximate count of each unique field-value combination, sorted in descending order.',
   },
 ];
 
@@ -64,6 +159,38 @@ export const NUMERIC_OPERATORS = [
     detail: 'sqrt(a)',
     documentation: 'Square root.',
   },
+  {
+    label: 'round',
+    detail: 'round(a [, d])',
+    documentation:
+      'Rounds the value of a. With one argument, rounds to the nearest integer; with two arguments, rounds to d decimal places.',
+  },
+  {
+    label: 'haversine',
+    detail: 'haversine(lat1, lon1, lat2, lon2)',
+    documentation:
+      'Computes the great-circle distance in kilometers between two geographic points given as latitude/longitude in degrees.',
+  },
+  {
+    label: 'toNumber',
+    detail: 'toNumber(fieldname)',
+    documentation: 'Converts a string field value to a numeric value.',
+  },
+  {
+    label: 'toInt',
+    detail: 'toInt(fieldname)',
+    documentation: 'Converts a field value to a 32-bit integer.',
+  },
+  {
+    label: 'toLong',
+    detail: 'toLong(fieldname)',
+    documentation: 'Converts a field value to a 64-bit long integer.',
+  },
+  {
+    label: 'toDouble',
+    detail: 'toDouble(fieldname)',
+    documentation: 'Converts a field value to a double-precision floating point number.',
+  },
 ];
 
 export const GENERAL_FUNCTIONS = [
@@ -76,6 +203,42 @@ export const GENERAL_FUNCTIONS = [
     label: 'coalesce',
     detail: 'coalesce(fieldname1, fieldname2, ... fieldnamex)',
     documentation: 'Returns the first non-null value from the list.',
+  },
+  {
+    label: 'case',
+    detail: 'case(cond1, val1, cond2, val2, ..., [default])',
+    documentation:
+      'Evaluates conditions in order and returns the value for the first true condition. Returns the optional default if none match. Supports up to 10 branches.',
+  },
+  {
+    label: 'if',
+    detail: 'if(condition, trueValue, falseValue)',
+    documentation: 'Returns trueValue if the condition is true, otherwise falseValue.',
+  },
+  {
+    label: 'isNumeric',
+    detail: 'isNumeric(fieldname)',
+    documentation: 'Returns true if the field value can be parsed as a number.',
+  },
+  {
+    label: 'messageSize',
+    detail: 'messageSize(fieldname)',
+    documentation: 'Returns the byte length of a string field.',
+  },
+  {
+    label: 'queryStartTime',
+    detail: 'queryStartTime()',
+    documentation: 'Returns the query window start time as epoch milliseconds.',
+  },
+  {
+    label: 'queryEndTime',
+    detail: 'queryEndTime()',
+    documentation: 'Returns the query window end time as epoch milliseconds.',
+  },
+  {
+    label: 'queryTimeRange',
+    detail: 'queryTimeRange()',
+    documentation: 'Returns the query window duration in milliseconds.',
   },
 ];
 
@@ -140,9 +303,66 @@ export const STRING_FUNCTIONS = [
     documentation: 'Replaces all instances of string2 in string1 with string3.',
   },
   {
+    label: 'regexReplace',
+    detail: 'regexReplace(fieldname, pattern, replacement)',
+    documentation:
+      'Replaces all substrings matching the regular expression pattern with replacement. Uses RE2 regex syntax.',
+  },
+  {
     label: 'strcontains',
     detail: 'strcontains(string1, string2)',
     documentation: 'Returns 1 if string1 contains string2 and 0 otherwise.',
+  },
+  {
+    label: 'startsWith',
+    detail: 'startsWith(string, searchValue)',
+    documentation: 'Returns 1 if string starts with searchValue and 0 otherwise.',
+  },
+  {
+    label: 'endsWith',
+    detail: 'endsWith(string, searchValue)',
+    documentation: 'Returns 1 if string ends with searchValue and 0 otherwise.',
+  },
+  {
+    label: 'split',
+    detail: 'split(string, delimiter)',
+    documentation: 'Splits a string by the specified delimiter and returns an array of substrings.',
+  },
+  {
+    label: 'urlencode',
+    detail: 'urlencode(string)',
+    documentation: 'URL-encodes the string.',
+  },
+  {
+    label: 'urldecode',
+    detail: 'urldecode(string)',
+    documentation: 'URL-decodes the string.',
+  },
+  {
+    label: 'base64encode',
+    detail: 'base64encode(string)',
+    documentation: 'Base64-encodes the string.',
+  },
+  {
+    label: 'base64decode',
+    detail: 'base64decode(string)',
+    documentation: 'Base64-decodes the string.',
+  },
+  {
+    label: 'hexToAscii',
+    detail: 'hexToAscii(value)',
+    documentation: 'Converts a hexadecimal string to ASCII text.',
+  },
+  {
+    label: 'hexToDec',
+    detail: 'hexToDec(value)',
+    documentation: 'Converts a hexadecimal string to a decimal integer.',
+  },
+  {
+    label: 'decToHex',
+    detail: 'decToHex(value)',
+    documentation:
+      'Converts a decimal integer to a lowercase hex string with a 0x prefix. Negative numbers produce a -0x prefix; non-integers are truncated.',
   },
 ];
 
@@ -173,6 +393,26 @@ export const DATETIME_FUNCTIONS = [
     detail: 'toMillis(fieldname)',
     documentation:
       'Converts the timestamp found in the named field into a number representing the milliseconds since the Unix epoch.',
+  },
+  {
+    label: 'now',
+    detail: 'now()',
+    documentation: 'Returns the time that query processing started, in epoch seconds.',
+  },
+  {
+    label: 'parseDate',
+    detail: 'parseDate(fieldname, format [, timezone])',
+    documentation: 'Parses a date string to epoch milliseconds using a Java DateTimeFormatter pattern.',
+  },
+  {
+    label: 'formatDate',
+    detail: 'formatDate(timestamp, format [, timezone])',
+    documentation: 'Formats a timestamp using a strftime-style format string. Also available as the alias strftime.',
+  },
+  {
+    label: 'strftime',
+    detail: 'strftime(timestamp, format [, timezone])',
+    documentation: 'Alias for formatDate. Formats a timestamp using a strftime-style format string.',
   },
 ];
 
@@ -207,6 +447,50 @@ export const IP_FUNCTIONS = [
     detail: 'isIpv6InSubnet(fieldname, string)',
     documentation: 'Returns true if the field is a valid v6 IP address within the specified v6 subnet.',
   },
+  {
+    label: 'ipv4ToNumber',
+    detail: 'ipv4ToNumber(fieldname)',
+    documentation: 'Converts an IPv4 address string to its numeric representation.',
+  },
+  {
+    label: 'isPrivateIP',
+    detail: 'isPrivateIP(fieldname)',
+    documentation: 'Returns true if the IP address is in a private range (RFC 1918).',
+  },
+  {
+    label: 'isPublicIP',
+    detail: 'isPublicIP(fieldname)',
+    documentation: 'Returns true if the IP address is publicly routable.',
+  },
+  {
+    label: 'isReservedIP',
+    detail: 'isReservedIP(fieldname)',
+    documentation: 'Returns true if the IP address is in a reserved range.',
+  },
+];
+
+export const JSON_FUNCTIONS = [
+  {
+    label: 'jsonParse',
+    detail: 'jsonParse(fieldname)',
+    documentation:
+      'Returns a map or list when the input is a string representation of a JSON object or array; returns empty otherwise.',
+  },
+  {
+    label: 'jsonStringify',
+    detail: 'jsonStringify(fieldname)',
+    documentation: 'Returns a JSON string from a map or list.',
+  },
+  {
+    label: 'jsonArraySize',
+    detail: 'jsonArraySize(fieldname)',
+    documentation: 'Returns the element count of a JSON array string field.',
+  },
+  {
+    label: 'jsonArrayContains',
+    detail: 'jsonArrayContains(fieldname, value)',
+    documentation: 'Returns true if the JSON array in the field contains the specified value (case-sensitive).',
+  },
 ];
 
 export const BOOLEAN_FUNCTIONS = [
@@ -224,6 +508,11 @@ export const BOOLEAN_FUNCTIONS = [
     label: 'isblank',
     detail: 'isblank(fieldname)',
     documentation: 'Returns true if the field is missing, an empty string, or contains only white space.',
+  },
+  {
+    label: 'isNumeric',
+    detail: 'isNumeric(fieldname)',
+    documentation: 'Returns true if the field value can be parsed as a number.',
   },
   {
     label: 'strcontains',
@@ -310,6 +599,7 @@ export const FIELD_AND_FILTER_FUNCTIONS = [
   ...STRING_FUNCTIONS,
   ...DATETIME_FUNCTIONS,
   ...IP_FUNCTIONS,
+  ...JSON_FUNCTIONS,
 ];
 
 export const FUNCTIONS = [...FIELD_AND_FILTER_FUNCTIONS, ...STATS_FUNCS];

--- a/src/language/logs/language.ts
+++ b/src/language/logs/language.ts
@@ -18,8 +18,58 @@ export const LIMIT = 'limit';
 export const PARSE = 'parse';
 export const DEDUP = 'dedup';
 export const ANOMALY = 'anomaly';
+export const ADDTOTALS = 'addtotals';
+export const RELEVANTFIELDS = 'relevantfields';
+export const EXPAND = 'expand';
+export const FILTERINDEX = 'filterIndex';
+export const UNNEST = 'unnest';
+export const UNMASK = 'unmask';
+export const LOOKUP = 'lookup';
+export const JOIN = 'join';
+export const WHERE = 'where';
+export const AUTOREGRESS = 'autoregress';
+export const LOGCOMPARE = 'logcompare';
+export const FILLDOWN = 'filldown';
+export const FILLMISSING = 'fillmissing';
+export const CIDRLOOKUP = 'cidrlookup';
+export const OUTLIER = 'outlier';
+export const ACCUM = 'accum';
+export const APPENDCOLS = 'appendcols';
+export const SESSIONIZE = 'sessionize';
+export const COUNTFREQUENT = 'countFrequent';
 
-export const LOGS_COMMANDS = [DISPLAY, FIELDS, FILTER, PATTERN, STATS, SORT, LIMIT, PARSE, DEDUP, DIFF, ANOMALY];
+export const LOGS_COMMANDS = [
+  DISPLAY,
+  FIELDS,
+  FILTER,
+  WHERE,
+  PATTERN,
+  STATS,
+  SORT,
+  LIMIT,
+  PARSE,
+  DEDUP,
+  DIFF,
+  ANOMALY,
+  ADDTOTALS,
+  RELEVANTFIELDS,
+  EXPAND,
+  FILTERINDEX,
+  UNNEST,
+  UNMASK,
+  LOOKUP,
+  JOIN,
+  AUTOREGRESS,
+  LOGCOMPARE,
+  FILLDOWN,
+  FILLMISSING,
+  CIDRLOOKUP,
+  OUTLIER,
+  ACCUM,
+  APPENDCOLS,
+  SESSIONIZE,
+  COUNTFREQUENT,
+];
 
 export const LOGS_LOGIC_OPERATORS = ['and', 'or', 'not'];
 
@@ -32,15 +82,37 @@ export const LOGS_FUNCTION_OPERATORS = [
   'least',
   'log',
   'sqrt',
+  'round',
+  'haversine',
+  'toNumber',
+  'toInt',
+  'toLong',
+  'toDouble',
   // datetime
   'bin',
   'datefloor',
   'dateceil',
   'fromMillis',
   'toMillis',
+  'now',
+  'parseDate',
+  'formatDate',
+  'strftime',
   // general
   'ispresent',
   'coalesce',
+  'case',
+  'if',
+  'isNumeric',
+  'messageSize',
+  'queryStartTime',
+  'queryEndTime',
+  'queryTimeRange',
+  // json
+  'jsonParse',
+  'jsonStringify',
+  'jsonArraySize',
+  'jsonArrayContains',
   // ip
   'isValidIp',
   'isValidIpV4',
@@ -48,6 +120,10 @@ export const LOGS_FUNCTION_OPERATORS = [
   'isIpInSubnet',
   'isIpv4InSubnet',
   'isIpv6InSubnet',
+  'ipv4ToNumber',
+  'isPrivateIP',
+  'isPublicIP',
+  'isReservedIP',
   // stats aggregation
   'avg',
   'count',
@@ -74,14 +150,34 @@ export const LOGS_FUNCTION_OPERATORS = [
   'tolower',
   'substr',
   'replace',
+  'regexReplace',
   'strcontains',
-  // field
-  'unmask',
+  'startsWith',
+  'endsWith',
+  'split',
+  // encoding
+  'urlencode',
+  'urldecode',
+  'base64encode',
+  'base64decode',
+  // hex
+  'hexToAscii',
+  'hexToDec',
+  'decToHex',
 ];
 
 export const SORT_DIRECTION_KEYWORDS = ['asc', 'desc'];
 export const DIFF_MODIFIERS = ['previousDay', 'previousWeek', 'previousMonth'];
-export const LOGS_KEYWORDS = ['like', 'by', 'in', 'as', ...SORT_DIRECTION_KEYWORDS, ...DIFF_MODIFIERS];
+export const PARSE_FORMATS = ['logfmt'];
+export const LOGS_KEYWORDS = [
+  'like',
+  'by',
+  'in',
+  'as',
+  ...SORT_DIRECTION_KEYWORDS,
+  ...DIFF_MODIFIERS,
+  ...PARSE_FORMATS,
+];
 
 export const language: CloudWatchLogsLanguage = {
   defaultToken: 'invalid',


### PR DESCRIPTION
Adds CloudWatch Logs Insights autocomplete for commands, the `logfmt` parse format, and functions, bringing the query editor to parity with the current [query syntax docs](https://docs.aws.amazon.com/AmazonCloudWatch/latest/logs/CWL_QuerySyntax.html), including recently launched features.

Follow-up to #543 (which stalled on unsigned commits) — this branch is signed/verified and additionally covers the full documented command/function set.

**Commands:** lookup, join, expand, relevantfields, addtotals, filterIndex, unnest, autoregress, logcompare, filldown, fillmissing, cidrlookup, outlier, accum, appendcols, sessionize, countFrequent, where

**Parse format:** logfmt

**Functions:** round, haversine, toNumber/toInt/toLong/toDouble, case, if, isNumeric, messageSize, queryStartTime/queryEndTime/queryTimeRange, jsonParse/jsonStringify/jsonArraySize/jsonArrayContains, ipv4ToNumber, isPrivateIP/isPublicIP/isReservedIP, now, parseDate, formatDate (strftime), startsWith, endsWith, regexReplace, split, urlencode/urldecode, base64encode/base64decode, hexToAscii/hexToDec/decToHex

Uses canonical casing from the docs (`startsWith`, `endsWith`, `regexReplace`) and moves `unmask` to the command list.

**Testing**
- Covered by existing provider unit tests (`CompletionItemProvider.test.ts`, `CloudWatchLogsLanguageProvider.test.ts`) — 26 passing; typecheck + lint clean.
- Verified live in Grafana with the plugin loaded; autocomplete surfaces the new commands/functions.
