### PR TITLE
Prepare release 12.10.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+## 12.10.0
+
+- Add promql visual query builder support in [#569](https://github.com/grafana/grafana-cloudwatch-datasource/pull/569)
+- CloudWatch Logs: Add support for querying by data source name and type in [#586](https://github.com/grafana/grafana-cloudwatch-datasource/pull/586)
+- Prefer per-datasource grafanaExternalId for Assume Role and /external-id in [#582](https://github.com/grafana/grafana-cloudwatch-datasource/pull/582)
+- Bump @grafana/* to 13.1.1 and update dependencies in [#602](https://github.com/grafana/grafana-cloudwatch-datasource/pull/602)
+
 ## 12.9.0
 
 - Add PromQL raw query editor support in [#568](https://github.com/grafana/grafana-cloudwatch-datasource/pull/568)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-cloudwatch-datasource",
-  "version": "12.9.0",
+  "version": "12.10.0",
   "scripts": {
     "build": "webpack -c ./webpack.config.ts --env production",
     "dev": "webpack -w -c ./webpack.config.ts --env development",


### PR DESCRIPTION
## Summary
- Bump version to 12.10.0
- Update CHANGELOG with commits since v12.9.0:
  - CloudWatch Logs: query by data source name and type (#586)
  - Prefer per-datasource grafanaExternalId for Assume Role and /external-id (#582)

## Test plan
- [x] `yarn build`
- [x] `mage -v`
- [x] `yarn test:ci` (one flaky SIGSEGV on LogGroupQueryScopeSelector, passed on retry)
- [ ] CI green
- [ ] After merge, run CD via [enghub release process](https://enghub.grafana-ops.net/docs/default/component/grafana-plugins-platform/plugins-ci-github-actions/010-plugins-ci-github-actions/#cd_1)


Made with [Cursor](https://cursor.com)