### PR TITLE
Prepare release 12.10.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,14 @@
 # Changelog
 
+## 12.10.1
+
+- fix(security): bump vulnerable deps (brace-expansion, immutable, fast-uri, ip-address) in [#612](https://github.com/grafana/grafana-cloudwatch-datasource/pull/612)
+- tests: add e2e tests for cloudwatch logs query by data source name and type in [#605](https://github.com/grafana/grafana-cloudwatch-datasource/pull/605)
+- Add documentation for cloudwatch promql support in [#606](https://github.com/grafana/grafana-cloudwatch-datasource/pull/606)
+- Chore: Set engine-strict in [#608](https://github.com/grafana/grafana-cloudwatch-datasource/pull/608)
+- Chore: Use npm as package manager in [#601](https://github.com/grafana/grafana-cloudwatch-datasource/pull/601)
+- Update dependencies in [#607](https://github.com/grafana/grafana-cloudwatch-datasource/pull/607)
+
 ## 12.10.0
 
 - Add promql visual query builder support in [#569](https://github.com/grafana/grafana-cloudwatch-datasource/pull/569)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "grafana-cloudwatch-datasource",
-  "version": "12.10.0",
+  "version": "12.10.1",
   "scripts": {
     "build": "webpack -c ./webpack.config.ts --env production",
     "dev": "webpack -w -c ./webpack.config.ts --env development",


### PR DESCRIPTION
- Bump version to `12.10.1` in `package.json`
- Update `CHANGELOG.md` with all 6 changes since [v12.10.0](https://github.com/grafana/grafana-cloudwatch-datasource/releases/tag/v12.10.0) (released 2026-07-28), including the security dependency bumps
- After merge: run the Plugins CI CD workflow per CONTRIBUTING.md