### PR TITLE
ci: onboard to the shared Cloud E2E workflow

### DIFF
--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -17,7 +17,8 @@ permissions:
 jobs:
   playwright-cloud:
     # Intentionally pinned to @main: data-sources-ci-workflows does not
-    # publish versioned tags for this workflow yet.
+    # publish versioned tags for this workflow yet. Allowed by the zizmor
+    # policy (`grafana/*: any`); review periodically.
     uses: grafana/data-sources-ci-workflows/.github/workflows/playwright-cloud.yml@main
     secrets: inherit
     permissions:

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -1,0 +1,35 @@
+name: Scheduled Cloud E2E tests
+
+on:
+  # Run nightly against the shared Cloud instance
+  schedule:
+    - cron: '0 9 * * *' # Daily at 09:00 UTC
+
+  # Allow engineers to run Cloud E2E on-demand (useful for debugging)
+  workflow_dispatch:
+
+# Reusable workflows can only narrow caller permissions, not escalate.
+# `id-token: write` is needed by the Vault OIDC step in playwright-cloud.yml.
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  playwright-cloud:
+    # Intentionally pinned to @main: data-sources-ci-workflows does not
+    # publish versioned tags for this workflow yet.
+    uses: grafana/data-sources-ci-workflows/.github/workflows/playwright-cloud.yml@main
+    secrets: inherit
+    permissions:
+      contents: read
+      id-token: write
+    with:
+      # Nightly Cloud E2E run, labelled with the DER run_stage vocabulary.
+      run-stage: nightly
+      # TODO(onboarding): map this datasource's AWS test-account credentials from Vault,
+      # in get-vault-secrets repo_secrets format (cf clickhouse-datasource cron.yml for the shape). e.g.:
+      # repo-secrets: |
+      #   AWS_ACCESS_KEY_ID=ds-instance:access_key_id
+      #   AWS_SECRET_ACCESS_KEY=ds-instance:secret_access_key
+      #   AWS_DEFAULT_REGION=ds-instance:region
+      # CloudWatch tests hit the public AWS API, so PDC is not expected to be needed.

--- a/.github/workflows/cron.yml
+++ b/.github/workflows/cron.yml
@@ -27,10 +27,12 @@ jobs:
     with:
       # Nightly Cloud E2E run, labelled with the DER run_stage vocabulary.
       run-stage: nightly
-      # TODO(onboarding): map this datasource's AWS test-account credentials from Vault,
-      # in get-vault-secrets repo_secrets format (cf clickhouse-datasource cron.yml for the shape). e.g.:
-      # repo-secrets: |
-      #   AWS_ACCESS_KEY_ID=ds-instance:access_key_id
-      #   AWS_SECRET_ACCESS_KEY=ds-instance:secret_access_key
-      #   AWS_DEFAULT_REGION=ds-instance:region
-      # CloudWatch tests hit the public AWS API, so PDC is not expected to be needed.
+      # The provisioned CloudWatch test instance is reached over PDC (aws network).
+      pdc-network-name: datasources-pdc-network-aws-datasourcese2e
+      # AWS test-account credentials, published to the data-sources Vault mount and
+      # read via get-vault-secrets (outputKey `cloudwatch`; see grafana/data-sources
+      # docs/security/vault-secrets-for-plugins.md for the payload schema).
+      repo-secrets: |
+        AWS_ACCESS_KEY_ID=cloudwatch:secure_accessKey
+        AWS_SECRET_ACCESS_KEY=cloudwatch:secure_secretKey
+        AWS_DEFAULT_REGION=cloudwatch:json_defaultRegion

--- a/tests/e2e/configEditor.spec.ts
+++ b/tests/e2e/configEditor.spec.ts
@@ -6,6 +6,10 @@ import { type CloudWatchJsonData } from '../../src/types';
 const PLUGIN_TYPE = 'cloudwatch';
 const PROVISIONED_FILE = 'datasources.yml';
 
+// GRAFANA_URL is set only by the Cloud cron workflow (playwright-cloud); its presence signals
+// a run against the shared Cloud instance rather than local/PR CI.
+const isCloudRun = !!process.env.GRAFANA_URL;
+
 // Selects a Private Data Source Connect network in the datasource config editor. The
 // combobox is a Grafana-core element, present only when PDC is available on the instance
 // (i.e. the shared Cloud instance), so it is called only when a network name is injected.
@@ -38,6 +42,12 @@ test.describe('Config editor', () => {
   });
 
   test.describe('provisioned datasource', () => {
+    // The shared Cloud instance doesn't apply the local provisioning/datasources/datasources.yml,
+    // so this assertion of the provisioned region can't run there (grafana/clickhouse-datasource#1934).
+    test.beforeEach(() => {
+      test.skip(isCloudRun, 'Provisioned-datasource assertions require local provisioning, not applied on Cloud.');
+    });
+
     test('should load the provisioned default region', async ({
       readProvisionedDataSource,
       gotoDataSourceConfigPage,
@@ -58,6 +68,7 @@ test.describe('Config editor', () => {
       'should pass health check for the provisioned datasource',
       { tag: '@aws' },
       async ({ readProvisionedDataSource, gotoDataSourceConfigPage }) => {
+        test.skip(isCloudRun, 'Health-checks the locally-provisioned datasource, not applied on Cloud.');
         const ds = await readProvisionedDataSource({ fileName: PROVISIONED_FILE });
         const configPage = await gotoDataSourceConfigPage(ds.uid);
 

--- a/tests/e2e/configEditor.spec.ts
+++ b/tests/e2e/configEditor.spec.ts
@@ -1,9 +1,18 @@
 import { expect, test } from '@grafana/plugin-e2e';
+import { Page } from '@playwright/test';
 
 import { type CloudWatchJsonData } from '../../src/types';
 
 const PLUGIN_TYPE = 'cloudwatch';
 const PROVISIONED_FILE = 'datasources.yml';
+
+// Selects a Private Data Source Connect network in the datasource config editor. The
+// combobox is a Grafana-core element, present only when PDC is available on the instance
+// (i.e. the shared Cloud instance), so it is called only when a network name is injected.
+async function configurePDC(page: Page, networkName: string) {
+  await page.getByRole('combobox', { name: 'Private data source connect' }).click();
+  await page.getByText(networkName).click();
+}
 
 test.describe('Config editor', () => {
   test.describe('rendering', () => {
@@ -74,5 +83,36 @@ test.describe('Config editor', () => {
       expect(response.ok()).toBe(false);
       await expect(configPage).toHaveAlert('error');
     });
+
+    test(
+      'valid injected credentials should pass the health check',
+      { tag: '@aws' },
+      async ({ createDataSourceConfigPage, page }) => {
+        // Consumes the AWS test-account credentials injected by the Cloud cron workflow
+        // (playwright-cloud) from the data-sources Vault mount as AWS_ACCESS_KEY_ID /
+        // AWS_SECRET_ACCESS_KEY / AWS_DEFAULT_REGION. Skipped when they are absent (fork PRs,
+        // or local runs with no Vault access).
+        const accessKey = process.env.AWS_ACCESS_KEY_ID;
+        const secretKey = process.env.AWS_SECRET_ACCESS_KEY;
+        const region = process.env.AWS_DEFAULT_REGION;
+        test.skip(!accessKey || !secretKey || !region, 'Requires the injected AWS credentials (Cloud cron / CI Vault)');
+
+        const configPage = await createDataSourceConfigPage({ type: PLUGIN_TYPE });
+
+        await page.getByRole('combobox', { name: 'Authentication Provider', exact: true }).click();
+        await page.getByText('Access & secret key', { exact: true }).click();
+        await page.getByLabel('Access Key ID').fill(accessKey ?? '');
+        await page.getByLabel('Secret Access Key').fill(secretKey ?? '');
+        await page.getByLabel('Default Region').click();
+        await page.getByText(region ?? '', { exact: true }).click();
+
+        if (process.env.DS_PDC_NETWORK_NAME) {
+          await configurePDC(page, process.env.DS_PDC_NETWORK_NAME);
+        }
+
+        const response = await configPage.saveAndTest();
+        expect(response.ok()).toBe(true);
+      }
+    );
   });
 });


### PR DESCRIPTION
**Draft / onboarding starter.** Adds a scheduled `cron.yml` that calls the shared `playwright-cloud.yml` (grafana/data-sources-ci-workflows), passing `run-stage: nightly` (DER `run_stage` vocabulary), the datasource's Vault `repo-secrets`, and the `pdc-network-name`.

**Before this is ready to merge**, one item remains:
- (stricter supply-chain posture) pin the reusable-workflow `uses:` to the post-`#12` `main` commit SHA instead of `@main`. `@main` is allowed here by the zizmor `grafana/*: any` policy, but SHA-pinning (with a `# main` comment, as graphite/mssql do) is more robust.

Part of the M1 phase-1 Cloud E2E onboarding. Depends on grafana/data-sources-ci-workflows#12 (which adds the `run-stage` input), so merge that first.
