### PR TITLE
chore(e2e): bump @grafana/plugin-e2e to 3.11.0 and drop dashboardNewLayouts workaround

### DIFF
--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -9,9 +9,6 @@ services:
     environment:
       # Prevent Grafana 13's splash screen from blocking Playwright.
       GF_FEATURE_TOGGLES_splashScreen: 'false'
-      # Nightly enables dashboardNewLayouts; plugin-e2e 3.10.0 still times out on
-      # the configure-panel selector in that layout. Keep the classic path for e2e.
-      GF_FEATURE_TOGGLES_dashboardNewLayouts: 'false'
       ACCESS_KEY: ${ACCESS_KEY:-}
       SECRET_KEY: ${SECRET_KEY:-}
     configs:

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "grafana-cloudwatch-datasource",
-  "version": "12.10.0",
+  "version": "12.10.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "grafana-cloudwatch-datasource",
-      "version": "12.10.0",
+      "version": "12.10.1",
       "license": "Apache-2.0",
       "dependencies": {
         "@emotion/css": "11.13.5",
@@ -29,7 +29,7 @@
         "@eslint/js": "9.39.5",
         "@grafana/e2e-selectors": "13.1.1",
         "@grafana/eslint-config": "9.0.0",
-        "@grafana/plugin-e2e": "3.10.0",
+        "@grafana/plugin-e2e": "3.11.0",
         "@grafana/sign-plugin": "3.3.3",
         "@grafana/tsconfig": "2.0.1",
         "@openfeature/core": "1.9.2",
@@ -1677,13 +1677,13 @@
       }
     },
     "node_modules/@grafana/plugin-e2e": {
-      "version": "3.10.0",
-      "resolved": "https://registry.npmjs.org/@grafana/plugin-e2e/-/plugin-e2e-3.10.0.tgz",
-      "integrity": "sha512-KvIC4klLuDdgT9Go61yY+Mm/8+8zSqF4lqhlMomBl53h9gx4PPYjoVRdK9e272oVJqlpgy42z7+OxHrs7IYY2g==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/@grafana/plugin-e2e/-/plugin-e2e-3.11.0.tgz",
+      "integrity": "sha512-kStVAbkmuQzgMaYwzm1leRGG+vRzuFj2JgojKeLFwPyZhL80OyVLC4L96ePmx2PZGmUXA9enMtMG8YqBx3uJdw==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "@grafana/e2e-selectors": "13.1.0-25644485979",
+        "@grafana/e2e-selectors": "13.2.0-30594044109",
         "yaml": "^2.3.4"
       },
       "engines": {
@@ -1700,29 +1700,13 @@
       }
     },
     "node_modules/@grafana/plugin-e2e/node_modules/@grafana/e2e-selectors": {
-      "version": "13.1.0-25644485979",
-      "resolved": "https://registry.npmjs.org/@grafana/e2e-selectors/-/e2e-selectors-13.1.0-25644485979.tgz",
-      "integrity": "sha512-2H+veZBayawey47iUTb5N69QK5KYHxzspe8uaauvLH7aSsjeyzH6nFubLkOVxz1JUOVtVrwOaH+libUwSaPMXw==",
+      "version": "13.2.0-30594044109",
+      "resolved": "https://registry.npmjs.org/@grafana/e2e-selectors/-/e2e-selectors-13.2.0-30594044109.tgz",
+      "integrity": "sha512-CRN0CTsSkAC3qQvufbR7duUzSX2Jfgc/g5ap+eSrjcFcS+vAVUDGfQVLK6y5ojN+B0gATNIbmVlCGngQxmm+eA==",
       "dev": true,
       "license": "Apache-2.0",
       "dependencies": {
-        "semver": "^7.7.0",
-        "tslib": "2.8.1",
-        "typescript": "6.0.2"
-      }
-    },
-    "node_modules/@grafana/plugin-e2e/node_modules/typescript": {
-      "version": "6.0.2",
-      "resolved": "https://registry.npmjs.org/typescript/-/typescript-6.0.2.tgz",
-      "integrity": "sha512-bGdAIrZ0wiGDo5l8c++HWtbaNCWTS4UTv7RaTH/ThVIgjkveJt83m74bBHMJkuCbslY8ixgLBVZJIOiQlQTjfQ==",
-      "dev": true,
-      "license": "Apache-2.0",
-      "bin": {
-        "tsc": "bin/tsc",
-        "tsserver": "bin/tsserver"
-      },
-      "engines": {
-        "node": ">=14.17"
+        "semver": "^7.7.0"
       }
     },
     "node_modules/@grafana/plugin-ui": {

--- a/package.json
+++ b/package.json
@@ -20,7 +20,7 @@
     "@eslint/js": "9.39.5",
     "@grafana/e2e-selectors": "13.1.1",
     "@grafana/eslint-config": "9.0.0",
-    "@grafana/plugin-e2e": "3.10.0",
+    "@grafana/plugin-e2e": "3.11.0",
     "@grafana/sign-plugin": "3.3.3",
     "@grafana/tsconfig": "2.0.1",
     "@openfeature/core": "1.9.2",


### PR DESCRIPTION
- Bump `@grafana/plugin-e2e` 3.10.0 -> 3.11.0, which fixes the panel-edit selectors against Grafana nightly's new dashboard layout
- Revert the temporary `GF_FEATURE_TOGGLES_dashboardNewLayouts: 'false'` e2e workaround from docker-compose
- Verification: the `e2e grafana-enterprise@nightly` CI job on this PR exercises the removed toggle path