### PR TITLE
test(e2e): inject the AWS credentials through the API, not the config editor

### DIFF
--- a/tests/e2e/configEditor.spec.ts
+++ b/tests/e2e/configEditor.spec.ts
@@ -95,35 +95,44 @@ test.describe('Config editor', () => {
       await expect(configPage).toHaveAlert('error');
     });
 
-    test(
-      'valid injected credentials should pass the health check',
-      { tag: '@aws' },
-      async ({ createDataSourceConfigPage, page }) => {
-        // Consumes the AWS test-account credentials injected by the Cloud cron workflow
-        // (playwright-cloud) from the data-sources Vault mount as AWS_ACCESS_KEY_ID /
-        // AWS_SECRET_ACCESS_KEY / AWS_DEFAULT_REGION. Skipped when they are absent (fork PRs,
-        // or local runs with no Vault access).
-        const accessKey = process.env.AWS_ACCESS_KEY_ID;
-        const secretKey = process.env.AWS_SECRET_ACCESS_KEY;
-        const region = process.env.AWS_DEFAULT_REGION;
-        test.skip(!accessKey || !secretKey || !region, 'Requires the injected AWS credentials (Cloud cron / CI Vault)');
+    // Trace capture is off here because a trace records the request body that carries the
+    // injected credentials. They also stay out of the DOM, because the datasource is created
+    // through the API: core renders Secret Access Key as a plain input, not a password input.
+    test.describe('injected credentials', () => {
+      test.use({ trace: 'off' });
 
-        const configPage = await createDataSourceConfigPage({ type: PLUGIN_TYPE });
+      test(
+        'valid injected credentials should pass the health check',
+        { tag: '@aws' },
+        async ({ createDataSource, gotoDataSourceConfigPage, page }) => {
+          // Consumes the AWS test-account credentials injected by the Cloud cron workflow
+          // (playwright-cloud) from the data-sources Vault mount as AWS_ACCESS_KEY_ID /
+          // AWS_SECRET_ACCESS_KEY / AWS_DEFAULT_REGION. Skipped when they are absent (fork PRs,
+          // or local runs with no Vault access).
+          const accessKey = process.env.AWS_ACCESS_KEY_ID;
+          const secretKey = process.env.AWS_SECRET_ACCESS_KEY;
+          const region = process.env.AWS_DEFAULT_REGION;
+          test.skip(
+            !accessKey || !secretKey || !region,
+            'Requires the injected AWS credentials (Cloud cron / CI Vault)'
+          );
 
-        await page.getByRole('combobox', { name: 'Authentication Provider', exact: true }).click();
-        await page.getByText('Access & secret key', { exact: true }).click();
-        await page.getByLabel('Access Key ID').fill(accessKey ?? '');
-        await page.getByLabel('Secret Access Key').fill(secretKey ?? '');
-        await page.getByLabel('Default Region').click();
-        await page.getByText(region ?? '', { exact: true }).click();
+          // Mirrors provisioning/datasources/datasources.yml, which is the same auth shape.
+          const ds = await createDataSource({
+            type: PLUGIN_TYPE,
+            jsonData: { authType: 'keys', defaultRegion: region ?? '' },
+            secureJsonData: { accessKey: accessKey ?? '', secretKey: secretKey ?? '' },
+          });
+          const configPage = await gotoDataSourceConfigPage(ds.uid);
 
-        if (process.env.DS_PDC_NETWORK_NAME) {
-          await configurePDC(page, process.env.DS_PDC_NETWORK_NAME);
+          if (process.env.DS_PDC_NETWORK_NAME) {
+            await configurePDC(page, process.env.DS_PDC_NETWORK_NAME);
+          }
+
+          const response = await configPage.saveAndTest();
+          expect(response.ok()).toBe(true);
         }
-
-        const response = await configPage.saveAndTest();
-        expect(response.ok()).toBe(true);
-      }
-    );
+      );
+    });
   });
 });

--- a/tests/e2e/configEditor.spec.ts
+++ b/tests/e2e/configEditor.spec.ts
@@ -1,5 +1,4 @@
 import { expect, test } from '@grafana/plugin-e2e';
-import { Page } from '@playwright/test';
 
 import { type CloudWatchJsonData } from '../../src/types';
 
@@ -9,14 +8,6 @@ const PROVISIONED_FILE = 'datasources.yml';
 // GRAFANA_URL is set only by the Cloud cron workflow (playwright-cloud); its presence signals
 // a run against the shared Cloud instance rather than local/PR CI.
 const isCloudRun = !!process.env.GRAFANA_URL;
-
-// Selects a Private Data Source Connect network in the datasource config editor. The
-// combobox is a Grafana-core element, present only when PDC is available on the instance
-// (i.e. the shared Cloud instance), so it is called only when a network name is injected.
-async function configurePDC(page: Page, networkName: string) {
-  await page.getByRole('combobox', { name: 'Private data source connect' }).click();
-  await page.getByText(networkName).click();
-}
 
 test.describe('Config editor', () => {
   test.describe('rendering', () => {
@@ -95,44 +86,7 @@ test.describe('Config editor', () => {
       await expect(configPage).toHaveAlert('error');
     });
 
-    // Trace capture is off here because a trace records the request body that carries the
-    // injected credentials. They also stay out of the DOM, because the datasource is created
-    // through the API: core renders Secret Access Key as a plain input, not a password input.
-    test.describe('injected credentials', () => {
-      test.use({ trace: 'off' });
-
-      test(
-        'valid injected credentials should pass the health check',
-        { tag: '@aws' },
-        async ({ createDataSource, gotoDataSourceConfigPage, page }) => {
-          // Consumes the AWS test-account credentials injected by the Cloud cron workflow
-          // (playwright-cloud) from the data-sources Vault mount as AWS_ACCESS_KEY_ID /
-          // AWS_SECRET_ACCESS_KEY / AWS_DEFAULT_REGION. Skipped when they are absent (fork PRs,
-          // or local runs with no Vault access).
-          const accessKey = process.env.AWS_ACCESS_KEY_ID;
-          const secretKey = process.env.AWS_SECRET_ACCESS_KEY;
-          const region = process.env.AWS_DEFAULT_REGION;
-          test.skip(
-            !accessKey || !secretKey || !region,
-            'Requires the injected AWS credentials (Cloud cron / CI Vault)'
-          );
-
-          // Mirrors provisioning/datasources/datasources.yml, which is the same auth shape.
-          const ds = await createDataSource({
-            type: PLUGIN_TYPE,
-            jsonData: { authType: 'keys', defaultRegion: region ?? '' },
-            secureJsonData: { accessKey: accessKey ?? '', secretKey: secretKey ?? '' },
-          });
-          const configPage = await gotoDataSourceConfigPage(ds.uid);
-
-          if (process.env.DS_PDC_NETWORK_NAME) {
-            await configurePDC(page, process.env.DS_PDC_NETWORK_NAME);
-          }
-
-          const response = await configPage.saveAndTest();
-          expect(response.ok()).toBe(true);
-        }
-      );
-    });
+    // The health check with real injected credentials lives in configEditorCredentials.spec.ts,
+    // which turns trace capture off at file scope.
   });
 });

--- a/tests/e2e/configEditorCredentials.spec.ts
+++ b/tests/e2e/configEditorCredentials.spec.ts
@@ -1,0 +1,53 @@
+import { expect, test } from '@grafana/plugin-e2e';
+import { Page } from '@playwright/test';
+
+const PLUGIN_TYPE = 'cloudwatch';
+
+// This test holds real credentials, so it lives in its own file with trace capture off. A trace
+// records the request body that carries them. Playwright rejects test.use({ trace }) inside a
+// describe group, so file scope is the narrowest scope available.
+test.use({ trace: 'off' });
+
+// Selects a Private Data Source Connect network in the datasource config editor. The
+// combobox is a Grafana-core element, present only when PDC is available on the instance
+// (i.e. the shared Cloud instance), so it is called only when a network name is injected.
+async function configurePDC(page: Page, networkName: string) {
+  await page.getByRole('combobox', { name: 'Private data source connect' }).click();
+  await page.getByText(networkName).click();
+}
+
+test.describe('Config editor', () => {
+  test.describe('save & test', () => {
+    test(
+      'valid injected credentials should pass the health check',
+      { tag: '@aws' },
+      async ({ createDataSource, gotoDataSourceConfigPage, page }) => {
+        // Consumes the AWS test-account credentials injected by the Cloud cron workflow
+        // (playwright-cloud) from the data-sources Vault mount as AWS_ACCESS_KEY_ID /
+        // AWS_SECRET_ACCESS_KEY / AWS_DEFAULT_REGION. Skipped when they are absent (fork PRs,
+        // or local runs with no Vault access).
+        const accessKey = process.env.AWS_ACCESS_KEY_ID;
+        const secretKey = process.env.AWS_SECRET_ACCESS_KEY;
+        const region = process.env.AWS_DEFAULT_REGION;
+        test.skip(!accessKey || !secretKey || !region, 'Requires the injected AWS credentials (Cloud cron / CI Vault)');
+
+        // Created through the API rather than typed into the editor, so the credentials stay out
+        // of the DOM: core renders Secret Access Key as a plain input, not a password input. The
+        // auth shape mirrors provisioning/datasources/datasources.yml.
+        const ds = await createDataSource({
+          type: PLUGIN_TYPE,
+          jsonData: { authType: 'keys', defaultRegion: region ?? '' },
+          secureJsonData: { accessKey: accessKey ?? '', secretKey: secretKey ?? '' },
+        });
+        const configPage = await gotoDataSourceConfigPage(ds.uid);
+
+        if (process.env.DS_PDC_NETWORK_NAME) {
+          await configurePDC(page, process.env.DS_PDC_NETWORK_NAME);
+        }
+
+        const response = await configPage.saveAndTest();
+        expect(response.ok()).toBe(true);
+      }
+    );
+  });
+});


### PR DESCRIPTION
## What

The Cloud health-check test creates the datasource through the API with `secureJsonData`, instead of typing the injected AWS credentials into the config editor. It moves into its own spec file, `configEditorCredentials.spec.ts`, which turns trace capture off.

## Why

A real credential typed into the editor reaches Playwright's captured output. A trace records the request body, and a DOM snapshot or screenshot records the field value, because core renders Secret Access Key as a plain input rather than a password input. Creating the datasource through the API keeps the value out of the DOM, and `trace: 'off'` keeps it out of the network log. Nothing publishes that output today, so this is hardening rather than a fix for a live exposure.

The auth shape mirrors `provisioning/datasources/datasources.yml`.

### Why its own spec file

Playwright rejects `test.use({ trace })` inside a describe group, because the option forces a new worker. File scope is the narrowest scope the option allows, and a separate file leaves trace capture on for the rest of `configEditor.spec.ts`. The full test title is unchanged.

## Coverage

Unchanged on Cloud. This is the only test there that exercises a real AWS backend, so it keeps running rather than being skipped.

PR CI skips it, because the injected credentials are absent. The e2e legs therefore prove collection and no regression, and the credential path itself needs the Cloud cron. The Cloud suite is red today for an unrelated reason, a frontend `TypeError` on `dashboardNewLayouts`, so a green Cloud run is not available as a check on this change.
