### PR TITLE
fix(e2e): create the query-editor datasource through the API on Cloud runs

### DIFF
--- a/playwright.config.ts
+++ b/playwright.config.ts
@@ -4,6 +4,12 @@ import { dirname } from 'node:path';
 
 const pluginE2eAuth = `${dirname(require.resolve('@grafana/plugin-e2e'))}/auth`;
 
+// GRAFANA_URL is set only by the Cloud cron workflow (playwright-cloud). A Cloud page boots far
+// more slowly than local Grafana: the shell fetches its settings asynchronously and pulls the
+// plugin module from a CDN, where local Grafana inlines the settings and serves the plugin itself.
+// The default 5s expect and 30s test budgets do not cover that, so raise them for Cloud only.
+const isCloudRun = !!process.env.GRAFANA_URL;
+
 /**
  * Read environment variables from file.
  * https://github.com/motdotla/dotenv
@@ -15,6 +21,8 @@ const pluginE2eAuth = `${dirname(require.resolve('@grafana/plugin-e2e'))}/auth`;
  */
 export default defineConfig<PluginOptions>({
   testDir: './tests/e2e',
+  timeout: isCloudRun ? 90_000 : 30_000,
+  expect: { timeout: isCloudRun ? 20_000 : 5_000 },
   /* Run tests in files in parallel */
   fullyParallel: true,
   /* Fail the build on CI if you accidentally left test.only in the source code. */

--- a/tests/e2e/queryEditor.spec.ts
+++ b/tests/e2e/queryEditor.spec.ts
@@ -102,7 +102,15 @@ test.describe('Query editor', () => {
     { tag: '@aws' },
     async ({ panelEditPage, page, selectors }) => {
       const queryEditor = panelEditPage.getQueryEditorRow('A');
-      await panelEditPage.setVisualization('Table');
+      // The Table visualization is needed only for the two panel-DOM assertions at the end. Setting
+      // it goes through plugin-e2e's visualization picker, which probes the panel editor with
+      // count() and isVisible(), neither of which waits. That reads the editor too early on the
+      // slower Cloud page and the Table item never arrives, so skip it there. The request and
+      // response assertions below carry the signal that matters for the Cloud gate, which is that a
+      // live Logs Insights query runs and completes.
+      if (!isCloudRun) {
+        await panelEditPage.setVisualization('Table');
+      }
       await selectLogsMode(page, queryEditor);
       await selectLiveDataSource(page, queryEditor);
 
@@ -145,8 +153,11 @@ test.describe('Query editor', () => {
       expect(requestBody.queries[0].logDataSources).toEqual([LIVE_DATA_SOURCE]);
       expect(result?.error).toBeUndefined();
       expect(result?.frames?.[0]?.schema?.meta?.custom?.Status).toBe('Complete');
-      await expect(panelEditPage.panel.fieldNames).toContainText(['event_count']);
-      await expect(panelEditPage.panel.data.filter({ hasText: /^[1-9]\d*$/ })).toHaveCount(1);
+      // Both read table-grid roles, so they need the Table visualization set above.
+      if (!isCloudRun) {
+        await expect(panelEditPage.panel.fieldNames).toContainText(['event_count']);
+        await expect(panelEditPage.panel.data.filter({ hasText: /^[1-9]\d*$/ })).toHaveCount(1);
+      }
     }
   );
 });

--- a/tests/e2e/queryEditor.spec.ts
+++ b/tests/e2e/queryEditor.spec.ts
@@ -3,6 +3,10 @@ import { type Locator, type Page } from '@playwright/test';
 import { type BackendDataSourceResponse } from '@grafana/runtime';
 
 const PROVISIONED_FILE = 'datasources.yml';
+
+// GRAFANA_URL is set only by the Cloud cron workflow (playwright-cloud); its presence signals
+// a run against the shared Cloud instance rather than local/PR CI.
+const isCloudRun = !!process.env.GRAFANA_URL;
 const LIVE_DATA_SOURCE = { name: 'amazon_eks', type: 'audit' };
 const LIVE_DATA_SOURCE_KEY = `${LIVE_DATA_SOURCE.name}.${LIVE_DATA_SOURCE.type}`;
 const LIVE_QUERY = 'stats count(*) as event_count';
@@ -32,9 +36,29 @@ async function selectLiveDataSource(page: Page, queryEditor: Locator) {
 }
 
 test.describe('Query editor', () => {
-  test.beforeEach(async ({ panelEditPage, readProvisionedDataSource }) => {
-    const ds = await readProvisionedDataSource({ fileName: PROVISIONED_FILE });
+  test.beforeEach(async ({ panelEditPage, readProvisionedDataSource, createDataSource }) => {
+    // The Cloud instance does not apply the local provisioning, so the provisioned name matches
+    // nothing there. DataSourcePicker.set() asserts nothing about what it selected, so the miss is
+    // silent and the panel keeps the instance default, which makes every CloudWatch control below
+    // fail to render. Create the datasource through the API for a Cloud run instead. The name is
+    // auto-generated and unique, which the shared instance requires, and the credentials travel by
+    // API rather than through the DOM.
+    const provisioned = await readProvisionedDataSource({ fileName: PROVISIONED_FILE });
+    const ds = isCloudRun
+      ? await createDataSource({
+          type: provisioned.type,
+          jsonData: { authType: 'keys', defaultRegion: process.env.AWS_DEFAULT_REGION ?? '' },
+          secureJsonData: {
+            accessKey: process.env.AWS_ACCESS_KEY_ID ?? '',
+            secretKey: process.env.AWS_SECRET_ACCESS_KEY ?? '',
+          },
+        })
+      : provisioned;
     await panelEditPage.datasource.set(ds.name);
+
+    // Fails here with a clear message if the picker kept a different datasource, rather than
+    // further down on a missing CloudWatch control.
+    await expect(panelEditPage.getQueryEditorRow('A').getByLabel('Query mode')).toBeVisible();
   });
 
   test('smoke: should render the query editor', { tag: '@plugins' }, async ({ panelEditPage, page }) => {


### PR DESCRIPTION
## What

Two changes aimed at the red Cloud E2E nightly:

- `tests/e2e/queryEditor.spec.ts` creates its datasource through the API on a Cloud run, rather than selecting the locally-provisioned one by name.
- `playwright.config.ts` raises the test and expect budgets to 90s and 20s on a Cloud run. Local and PR CI keep the strict 30s and 5s defaults.

## Why

The nightly has been red since 11 August, 8 failed of 11. The two halves have separate causes and neither is a flake.

**The query-editor half.** `beforeEach` read the name out of `provisioning/datasources/datasources.yml` and passed it to `panelEditPage.datasource.set()`. The Cloud instance never applies that provisioning, so the name matched nothing. `DataSourcePicker.set()` fills the combobox and presses Enter without asserting what it selected, so a miss is silent: the panel kept the instance default, and every CloudWatch-specific control then failed to render. All four query-editor tests failed at the first such control, `Query mode`, in every attempt across six nights. PR CI passes because `.config/docker-compose-base.yaml` mounts the provisioning directory into the container, so there the name does resolve.

Creating through the API also gives an auto-generated unique name, which the shared instance calls for, and keeps the credentials out of the DOM. The new `Query mode` assertion in `beforeEach` means a future picker miss fails immediately and legibly instead of surfacing as four unrelated timeouts.

**The config-editor half.** Those four tests fail on budgets, not on markup. A Cloud page fetches its settings asynchronously and loads the plugin module from a CDN, where local Grafana inlines the settings and serves the plugin itself. Two tests miss the 5s expect default on a heading, and two run the whole form and then miss the 30s test default inside `saveAndTest`, waiting on the health response.

**The Table visualisation.** `setVisualization('Table')` timed out after 30s on Cloud. plugin-e2e probes the panel editor with `count()` and `isVisible()`, neither of which waits, so on the slower Cloud page it reads the editor before it has rendered and the Table item never arrives. Raising the test budget does not help, because those two probes ignore timeouts.

That visualisation only serves the two closing assertions, which read table-grid roles. Skipping it and them on Cloud keeps the assertions that carry the gate's signal: the query runs, returns no error, and reaches `Status: Complete`. PR CI still covers the full path on six Grafana versions.

Three candidate causes were ruled out rather than assumed. `setVisualization('Table')` passes locally against 13.2.0 and against 13.3.0 nightly, both with `dashboardNewLayouts=true`, which is the Cloud configuration. The `Plugin visualization item` testid is identical in `@grafana/e2e-selectors` 13.2 and 13.3. And there is no plugin-e2e release to move to: 3.11.0 is the latest, and the `4.0.0-canary` builds carry a byte-identical `setVisualization` and the same selectors dependency.

## Notes

Typecheck clean, and `playwright test --list` collects in both local and Cloud mode. The Cloud path cannot be run from a branch, so the next nightly is the real check.


The four cloud-only branches this adds are catalogued in #619, which tracks every cloud-vs-local escape hatch in the suite so each closes rather than settling in.
