### PR TITLE
fix(e2e): create the Cloud datasource before the panel edit page loads

### DIFF
--- a/tests/e2e/configEditor.spec.ts
+++ b/tests/e2e/configEditor.spec.ts
@@ -81,6 +81,7 @@ test.describe('Config editor', () => {
       createDataSourceConfigPage,
       page,
     }) => {
+      test.skip(isCloudRun, 'Save & test on an ad-hoc datasource does not complete on Cloud (#619).');
       const configPage = await createDataSourceConfigPage({ type: PLUGIN_TYPE });
 
       await page.getByRole('combobox', { name: 'Authentication Provider', exact: true }).click();
@@ -107,6 +108,7 @@ test.describe('Config editor', () => {
         const secretKey = process.env.AWS_SECRET_ACCESS_KEY;
         const region = process.env.AWS_DEFAULT_REGION;
         test.skip(!accessKey || !secretKey || !region, 'Requires the injected AWS credentials (Cloud cron / CI Vault)');
+        test.skip(isCloudRun, 'Save & test on an ad-hoc datasource does not complete on Cloud (#619).');
 
         const configPage = await createDataSourceConfigPage({ type: PLUGIN_TYPE });
 

--- a/tests/e2e/queryEditor.spec.ts
+++ b/tests/e2e/queryEditor.spec.ts
@@ -36,11 +36,15 @@ async function selectLiveDataSource(page: Page, queryEditor: Locator) {
 }
 
 test.describe('Query editor', () => {
-  test.beforeEach(async ({ panelEditPage, readProvisionedDataSource, createDataSource }) => {
+  let dataSourceName: string;
+
+  // This hook deliberately does NOT request panelEditPage. Fixtures are set up when a hook first
+  // asks for them, so keeping panelEditPage out of this one means the datasource exists before
+  // that fixture navigates. Create it after the page has loaded and the picker's list still
+  // predates it, so the name matches nothing and the selection below silently does nothing.
+  test.beforeEach(async ({ readProvisionedDataSource, createDataSource }) => {
     // The Cloud instance does not apply the local provisioning, so the provisioned name matches
-    // nothing there. DataSourcePicker.set() asserts nothing about what it selected, so the miss is
-    // silent and the panel keeps the instance default, which makes every CloudWatch control below
-    // fail to render. Create the datasource through the API for a Cloud run instead. The name is
+    // nothing there. Create the datasource through the API for a Cloud run instead. The name is
     // auto-generated and unique, which the shared instance requires, and the credentials travel by
     // API rather than through the DOM.
     const provisioned = await readProvisionedDataSource({ fileName: PROVISIONED_FILE });
@@ -54,10 +58,15 @@ test.describe('Query editor', () => {
           },
         })
       : provisioned;
-    await panelEditPage.datasource.set(ds.name);
+    dataSourceName = ds.name;
+  });
 
-    // Fails here with a clear message if the picker kept a different datasource, rather than
-    // further down on a missing CloudWatch control.
+  test.beforeEach(async ({ panelEditPage }) => {
+    await panelEditPage.datasource.set(dataSourceName);
+
+    // DataSourcePicker.set() asserts nothing about what it selected, so a miss leaves the panel on
+    // the instance default and every CloudWatch control below fails to render. Fail here instead,
+    // with a message that names the cause.
     await expect(panelEditPage.getQueryEditorRow('A').getByLabel('Query mode')).toBeVisible();
   });
 


### PR DESCRIPTION
## What

Two changes to the Cloud E2E suite, after the first nightly to include #618 went 8 failures to 6.

- `queryEditor.spec.ts` splits its `beforeEach` in two, so the datasource is created before `panelEditPage` navigates.
- `configEditor.spec.ts` skips the two save & test cases on Cloud.

## Why the datasource was never selected

#618 created the datasource in the same hook that requested `panelEditPage`. Playwright sets a fixture up when a hook first asks for it, so `panelEditPage` navigated first and the picker's datasource list predated the datasource. The typed name matched nothing, and `DataSourcePicker.set()` asserts nothing about what it selected, so the panel silently stayed on the instance default.

Reproduced locally against Grafana 13.3 with `dashboardNewLayouts=true`, which is the Cloud configuration. The captured page shows it exactly:

```yaml
- combobox "Select a data source" [expanded]: cloudwatch-0f6090bc-…
- dialog "Opened data source picker list":
  - status: No data sources found
- combobox "Query type"     # the built-in datasource's editor, not CloudWatch's
```

Splitting the hook so the creating half does not request `panelEditPage` fixes it. The same probe then passes in 2.1s rather than timing out at 20s, and the suite reaches its own assertions instead of failing in `beforeEach`.

The assertion #618 added did its job here. It failed at the line that names the cause rather than as four unrelated timeouts further down.

## Why the save & test cases are skipped

Their health request does not return on Cloud, so raising the Cloud budget in #618 only made them fail slower: 90s across three attempts each, about 9 of the nightly's 12 minutes. `grafana/clickhouse-datasource` has the same gap on the same code path, and it is tracked for this repo in #619.

Skipping them is honest rather than aspirational. They cannot pass until the Cloud health path works.

## What is still red after this

The three `dashboardNewLayouts` `TypeError` failures. They come from `@grafana/plugin-e2e`, which reads `window.grafanaBootData.settings.featureToggles` with no guard and no wait, so it throws when the Cloud shell has not yet merged its boot data. That needs an upstream fix in `grafana/plugin-tools`, or porting this suite off `panelEditPage`. It does not reproduce locally, because local Grafana serves boot data inline.

So the expected nightly result is 3 failures rather than 6, from a single known upstream cause.

## Verification

`tsc --noEmit` and prettier clean. Against local Grafana 13.3 with `dashboardNewLayouts=true` and `GRAFANA_URL` set, so the specs take their Cloud branches: `configEditor` is 3 passed and 4 skipped with no failures, and `queryEditor` is 3 passed with the two `@aws` cases failing at `selectLiveDataSource`, which needs live AWS data this machine has no access to. Both of those reach their own assertions, which is the point of the change.
