### PR TITLE
fix(cloudwatch): use non-nullable types in empty metric frames

### DIFF
--- a/pkg/cloudwatch/response_parser.go
+++ b/pkg/cloudwatch/response_parser.go
@@ -201,8 +201,8 @@ func buildDataFrames(ctx context.Context, aggregatedResponse models.QueryRowResp
 					}
 				}
 
-				timeField := data.NewField(data.TimeSeriesTimeFieldName, nil, []*time.Time{})
-				valueField := data.NewField(data.TimeSeriesValueFieldName, labels, []*float64{})
+				timeField := data.NewField(data.TimeSeriesTimeFieldName, nil, []time.Time{})
+				valueField := data.NewField(data.TimeSeriesValueFieldName, labels, []float64{})
 
 				valueField.SetConfig(&data.FieldConfig{DisplayNameFromDS: label, Links: createDataLinks(deepLink)})
 

--- a/pkg/cloudwatch/response_parser_test.go
+++ b/pkg/cloudwatch/response_parser_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/grafana/grafana-cloudwatch-datasource/pkg/cloudwatch/features"
 	"github.com/grafana/grafana-cloudwatch-datasource/pkg/cloudwatch/models"
+	"github.com/grafana/grafana-plugin-sdk-go/data"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
@@ -333,6 +334,11 @@ func Test_buildDataFrames_parse_label_to_name_and_labels(t *testing.T) {
 		assert.Equal(t, "lb1", frames[0].Fields[1].Labels["LoadBalancer"])
 		assert.Equal(t, "some label", frames[1].Name)
 		assert.Equal(t, "lb2", frames[1].Fields[1].Labels["LoadBalancer"])
+
+		assert.Equal(t, data.FieldTypeTime, frames[0].Fields[0].Type())
+		assert.Equal(t, data.FieldTypeFloat64, frames[0].Fields[1].Type())
+		assert.Equal(t, data.FieldTypeTime, frames[1].Fields[0].Type())
+		assert.Equal(t, data.FieldTypeFloat64, frames[1].Fields[1].Type())
 	})
 
 	t.Run("when no values are returned and a multi-valued template variable and two single-valued dimensions are used", func(t *testing.T) {


### PR DESCRIPTION
**What is this feature?**

Empty metric frames now use `[]time.Time{}` and `[]float64{}` instead of the nullable pointer types.

**Why do we need this feature?**

`[]*time.Time{}` produces a `FieldTypeNullableTime` field. SQL Expressions' `ConvertToFullLong` accepts only `FieldTypeTime`. So when a multi-valued dimension query returns data for some dimensions and none for others, the frames with data route the whole set through `ConvertToFullLong`, and the empty frames fail with a missing time field error.

**Who is this feature for?**

Users querying CloudWatch metrics through SQL Expressions.

**Which issue(s) does this PR fix?**

Fixes grafana/grafana#103880.

**Special notes for your reviewer:**

Same change as grafana/grafana#124631, already merged there. The change is two characters: the `*` on each type. AWS SDK v2 already returns non-nullable `Timestamps` and `Values`, so this aligns the empty-frame path with the data path.
