### PR TITLE
chore(lint): allow the deprecated alias field in the migration test

### DIFF
--- a/pkg/cloudwatch/models/cloudwatch_query_test.go
+++ b/pkg/cloudwatch/models/cloudwatch_query_test.go
@@ -961,7 +961,7 @@ func Test_migrateAliasToDynamicLabel_single_query_preserves_old_alias_and_create
 					Region:     "us-east-1",
 					Namespace:  "ec2",
 					MetricName: utils.Pointer("CPUUtilization"),
-					Alias:      utils.Pointer(tc.inputAlias),
+					Alias:      utils.Pointer(tc.inputAlias), //nolint:staticcheck // the deprecated field is the input this migration test exercises
 					Dimensions: &dataquery.Dimensions{
 						"InstanceId": dataquery.StringOrArrayOfString{ArrayOfString: []string{"test"}},
 					},


### PR DESCRIPTION
The shared CI at `ci-cd-workflows/v11.1.1` carries a newer golangci-lint whose staticcheck flags SA1019 on the alias-to-label migration test, which sets the deprecated `Alias` field on purpose — the deprecated input is what the migration under test consumes. An inline nolint with the reason keeps the coverage.

Unblocks #627 (this repo's pin move to v11.1.1) and the bundled-image builds, which already run at v11.1.1 through the shared pipeline.
