### PR TITLE
ci: ship merges to dev0 and releases to the full rollout through the bundled pipeline

### DIFF
--- a/.github/workflows/bundled-image.yml
+++ b/.github/workflows/bundled-image.yml
@@ -34,6 +34,14 @@ on:
       - tests/**
   workflow_dispatch:
     inputs:
+      ref:
+        description: >-
+          Tag or commit SHA to build. Leave empty to build the commit the run starts from. Set it
+          to the release tag when a release build is re-run, so the image matches the published
+          version and not the current main HEAD.
+        type: string
+        required: false
+        default: ""
       grafana-image:
         description: >-
           Grafana base image to bundle onto. Leave empty to read the first wave's current image.
@@ -73,6 +81,7 @@ jobs:
       contents: read
       id-token: write
     with:
+      ref: ${{ inputs.ref }}
       grafana-image: ${{ inputs.grafana-image }}
       push-image: ${{ inputs.push-image }}
       trigger-argo: ${{ inputs.trigger-argo }}

--- a/.github/workflows/bundled-image.yml
+++ b/.github/workflows/bundled-image.yml
@@ -8,10 +8,12 @@
 # unchanged in every plugin repo that adopts bundled images. Keep it that way: anything that has to
 # differ per repo belongs in the shared workflow's defaults, not copied into three callers.
 #
-# Manual dispatch only, deliberately. Bundled delivery is being rolled out to the pilot data
-# sources one step at a time, and a push trigger would build an image for every commit to main
-# before the rollout is proven. When the push trigger is added it wants a paths filter, so a
-# docs-only or test-only commit does not rebuild the image.
+# Push events ship every merge to main to the dev0 wave through the shared pipeline: the
+# build is pushed and the dev-only rollout is triggered, gated and benched. The paths
+# filter keeps docs- and test-only commits from rebuilding the image. A published
+# release builds from the tag and triggers the full rollout, so merging a release PR
+# delivers it to Cloud. Manual dispatch keeps the explicit inputs, targets the full
+# rollout, and stays as the fallback.
 #
 # Note on the app grant:
 # The shared workflow reads the Grafana base image from one line of a private infrastructure repo.
@@ -22,6 +24,14 @@
 name: Plugins - Bundled image
 
 on:
+  release:
+    types: [published]
+  push:
+    branches: [main]
+    paths-ignore:
+      - "**/*.md"
+      - docs/**
+      - tests/**
   workflow_dispatch:
     inputs:
       grafana-image:

--- a/.github/workflows/push.yml
+++ b/.github/workflows/push.yml
@@ -82,3 +82,7 @@ jobs:
       # resolves today: go-version from go.mod, and the shared golangci-lint default.
       go-version: '1.26.5'
       golangci-lint-version: '2.12.2'
+      # The backend ships to dev0 per merge through the bundled pipeline
+      # (bundled-image.yml), so this job publishes the frontend to the dev catalog
+      # and does not also trigger the backend rollout.
+      deploy: false


### PR DESCRIPTION
## What

Completes CloudWatch's bundled-images cutover with the same trigger pair ClickHouse and Elasticsearch already run:

- **Every merge to \`main\`** builds the bundled image and triggers the gated dev0-only rollout, with a paths filter so docs- and test-only commits skip the build. The shared pipeline skips release-please merges on this path, because the release those merges create fires the full rollout for the same commit.
- **Every published release** builds from the tag and triggers the full dev0-to-prod rollout, with the prod0 hold as the one human touch.
- **\`deploy: false\` on publish-dev**: the dev-catalog job keeps publishing the frontend and stops rolling the backend, leaving the bundled pipeline as the single writer of the dev0 waves entry.
- The dispatch form gains a \`ref\` input forwarded to the shared pipeline, so a recovery dispatch can build the released tag instead of main HEAD (same change as grafana/clickhouse-datasource#2148).

## Why

CloudWatch's first bundled rollout ran attended today and is walking production green (dev0, ops, prod0, prod1 at the time of writing). Until this lands, CloudWatch merges still publish through the dev catalog — so every ordinary merge rewrites dev0 back to the catalog path, the defect the other pilots closed with this same pair. Landing it makes per-merge delivery and release-triggered rollouts live on the third pilot.

Mirrors grafana/grafana-elasticsearch-datasource#425 and grafana/clickhouse-datasource#2140 + #2143.